### PR TITLE
ci: add Android release publishing workflow to Google Play

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: PR Checks
+name: CMP Build
 
 on:
   pull_request:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,0 +1,53 @@
+name: Publish Android Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+
+jobs:
+  publish_android_release:
+    name: Generate Android Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Android keystore
+        id: android_keystore
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: upload-keystore.jks
+          encodedString: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+
+      - name: Create key.properties file
+        run: |
+          echo "storeFile=${{ steps.android_keystore.outputs.filePath }}" > key.properties
+          echo "storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}" >> key.properties
+          echo "keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> key.properties
+          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" >> key.properties
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Start Android Release Build
+        run: ./gradlew composeApp:bundleRelease
+
+      - name: Upload Release Build to Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-artifacts
+          path: composeApp/build/outputs/bundle/release/composeApp-release.aab
+
+      - name: Release Build to production track
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.ANDROID_PLAYSTORE_ACCOUNT_KEY }}
+          packageName: com.nacchofer31.randomboxd
+          releaseFiles: composeApp/build/outputs/bundle/release/composeApp-release.aab
+          track: production
+          status: completed

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,11 @@ coverage:
   round: down
   range: "70...100"
 
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
 ignore:
   # Android platform-specific (require device context)
   - "composeApp/src/androidMain/kotlin/com/nacchofer31/randomboxd/MainActivity.kt"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,6 +1,6 @@
-import java.util.Properties
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.util.Properties
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -146,12 +147,25 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            val props = Properties()
+            val keyPropsFile = rootProject.file("key.properties")
+            if (keyPropsFile.exists()) props.load(keyPropsFile.inputStream())
+            storeFile = props["storeFile"]?.let { file(it) }
+            storePassword = props["storePassword"] as String?
+            keyPassword = props["keyPassword"] as String?
+            keyAlias = props["keyAlias"] as String?
+        }
+    }
+
     buildTypes {
         debug {
             enableAndroidTestCoverage = true
         }
         getByName("release") {
             isMinifyEnabled = false
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 


### PR DESCRIPTION
## Summary

  - Added `.github/workflows/publish-android.yml` to automate Android release builds and publishing to Google Play production track, triggered on version tags (`v*.*.*`)
  or manually via `workflow_dispatch`
  - Added signing configuration in `composeApp/build.gradle.kts` that reads keystore credentials from a `key.properties` file at project root (generated at CI time from
  GitHub secrets)