### PR TITLE
fix: updated to actions/checkout@v6 and avoid running following jobs if no new code added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -8,7 +8,7 @@ jobs:
     name: Instrumented Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,8 +29,6 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   spotless:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.source == 'true'
     uses: ./.github/workflows/spotless.yml
     permissions:
       contents: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,20 +11,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            source:
+              - 'composeApp/src/**/*.kt'
+              - 'composeApp/src/**/*.java'
+
   build:
     uses: ./.github/workflows/build.yml
 
   spotless:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.source == 'true'
     uses: ./.github/workflows/spotless.yml
     permissions:
       contents: write
 
   unit-tests:
-    needs: build
+    needs: [ detect-changes, build ]
+    if: needs.detect-changes.outputs.source == 'true'
     uses: ./.github/workflows/unit-tests.yml
 
   instrumented-tests:
-    needs: build
+    needs: [ detect-changes, build ]
+    if: needs.detect-changes.outputs.source == 'true'
     uses: ./.github/workflows/instrumented-tests.yml
 
   coverage:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -11,7 +11,7 @@ jobs:
     name: Generate Android Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download Android keystore
         id: android_keystore

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -8,7 +8,7 @@ jobs:
     name: Spotless
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## CI: Optimize workflow triggers and update checkout action

  ### Changes
  - Added `detect-changes` job in `pr-checks.yml` using `dorny/paths-filter@v3` to detect changes in Kotlin/Java source files (`composeApp/src/**/*.kt`, `composeApp/src/**/*.java`)
  - `spotless`, `unit-tests`, `instrumented-tests` and `coverage` jobs now only run when source files are modified — skipped for config/dependency-only changes (e.g. `build.gradle.kts`, `gradle.properties`)
  - `build` job continues to run on every push/PR to verify the project compiles regardless of what changed
  - Updated `actions/checkout` from `v4` to `v6` across all workflows (`build.yml`, `unit-tests.yml`, `instrumented-tests.yml`, `spotless.yml`, `coverage.yml`, `publish-android.yml`, `pr-checks.yml`)