### PR TITLE
fix(compose): split monolithic state reads to reduce unnecessary recompositions

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -368,16 +368,16 @@ tasks.register("fullCoverageReport") {
             val coverage = if (total > 0) (totalCovered.toDouble() / total * 100) else 0.0
 
             println("")
-            println("=" .repeat(50))
+            println("=".repeat(50))
             println("  CODE COVERAGE SUMMARY")
-            println("=" .repeat(50))
+            println("=".repeat(50))
             println("  Total Lines:     $total")
             println("  Covered Lines:   $totalCovered")
             println("  Missed Lines:    $totalMissed")
             println("  Coverage:        ${"%.1f".format(coverage)}%")
-            println("=" .repeat(50))
+            println("=".repeat(50))
             println("  HTML Report:     file://${layout.buildDirectory.get().asFile.absolutePath}/jacocoHtml/index.html")
-            println("=" .repeat(50))
+            println("=".repeat(50))
             println("")
         } else {
             println("Warning: JaCoCo XML report not found at ${reportFile.absolutePath}")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -346,4 +346,41 @@ tasks.register("fullCoverageReport") {
     group = "Reporting"
     description = "Runs all tests (unit + android) and generates full coverage report."
     dependsOn("testDebugUnitTest", "connectedDebugAndroidTest", "jacocoTestReport")
+
+    doLast {
+        val xmlReport = layout.buildDirectory.file("reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+        val reportFile = xmlReport.get().asFile
+
+        if (reportFile.exists()) {
+            val content = reportFile.readText()
+            val regex = Regex("""<counter type="LINE" missed="(\d+)" covered="(\d+)"/>""")
+            val matches = regex.findAll(content).toList()
+
+            var totalMissed = 0
+            var totalCovered = 0
+
+            for (match in matches) {
+                totalMissed += match.groupValues[1].toInt()
+                totalCovered += match.groupValues[2].toInt()
+            }
+
+            val total = totalMissed + totalCovered
+            val coverage = if (total > 0) (totalCovered.toDouble() / total * 100) else 0.0
+
+            println("")
+            println("=" .repeat(50))
+            println("  CODE COVERAGE SUMMARY")
+            println("=" .repeat(50))
+            println("  Total Lines:     $total")
+            println("  Covered Lines:   $totalCovered")
+            println("  Missed Lines:    $totalMissed")
+            println("  Coverage:        ${"%.1f".format(coverage)}%")
+            println("=" .repeat(50))
+            println("  HTML Report:     file://${layout.buildDirectory.get().asFile.absolutePath}/jacocoHtml/index.html")
+            println("=" .repeat(50))
+            println("")
+        } else {
+            println("Warning: JaCoCo XML report not found at ${reportFile.absolutePath}")
+        }
+    }
 }

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/LoadingOrPromptTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/LoadingOrPromptTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nacchofer31.randomboxd.random_film.presentation.components.LoadingOrPrompt
-import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmState
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +18,7 @@ class LoadingOrPromptTest {
     @Test
     fun loading_indicator_is_displayed_when_isLoading_is_true() {
         composeTestRule.setContent {
-            LoadingOrPrompt(state = RandomFilmState(isLoading = true))
+            LoadingOrPrompt(isLoading = true)
         }
 
         composeTestRule.onNodeWithTag("test-loading-indicator").assertIsDisplayed()
@@ -28,7 +27,7 @@ class LoadingOrPromptTest {
     @Test
     fun loading_indicator_does_not_exist_when_isLoading_is_false() {
         composeTestRule.setContent {
-            LoadingOrPrompt(state = RandomFilmState(isLoading = false))
+            LoadingOrPrompt(isLoading = false)
         }
 
         composeTestRule.onNodeWithTag("test-loading-indicator").assertDoesNotExist()
@@ -37,7 +36,7 @@ class LoadingOrPromptTest {
     @Test
     fun rolling_dice_text_is_shown_when_loading() {
         composeTestRule.setContent {
-            LoadingOrPrompt(state = RandomFilmState(isLoading = true))
+            LoadingOrPrompt(isLoading = true)
         }
 
         composeTestRule.onNodeWithText("Rolling the dice...").assertIsDisplayed()
@@ -46,7 +45,7 @@ class LoadingOrPromptTest {
     @Test
     fun finding_random_movie_text_is_shown_when_loading() {
         composeTestRule.setContent {
-            LoadingOrPrompt(state = RandomFilmState(isLoading = true))
+            LoadingOrPrompt(isLoading = true)
         }
 
         composeTestRule.onNodeWithText("Finding your random movie").assertIsDisplayed()

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
@@ -13,7 +13,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nacchofer31.randomboxd.core.domain.DataError
 import com.nacchofer31.randomboxd.random_film.domain.model.Film
 import com.nacchofer31.randomboxd.random_film.domain.model.FilmGenre
-import com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode
 import com.nacchofer31.randomboxd.random_film.domain.model.UserName
 import com.nacchofer31.randomboxd.random_film.presentation.RandomFilmScreen
 import com.nacchofer31.randomboxd.random_film.presentation.RandomFilmScreenRoot

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
@@ -10,12 +10,13 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nacchofer31.randomboxd.core.domain.DataError
 import com.nacchofer31.randomboxd.random_film.domain.model.Film
 import com.nacchofer31.randomboxd.random_film.domain.model.FilmGenre
+import com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode
 import com.nacchofer31.randomboxd.random_film.domain.model.UserName
 import com.nacchofer31.randomboxd.random_film.presentation.RandomFilmScreen
 import com.nacchofer31.randomboxd.random_film.presentation.RandomFilmScreenRoot
-import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmState
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
@@ -76,15 +77,12 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state =
-                    RandomFilmState(
-                        resultFilm =
-                            Film(
-                                slug = "test-slug",
-                                name = "test-name",
-                                releaseYear = 2000,
-                                imageUrl = "test-image-url",
-                            ),
+                resultFilm =
+                    Film(
+                        slug = "test-slug",
+                        name = "test-name",
+                        releaseYear = 2000,
+                        imageUrl = "test-image-url",
                     ),
             ) { }
         }
@@ -99,7 +97,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(resultError = com.nacchofer31.randomboxd.core.domain.DataError.Remote.NO_RESULTS),
+                resultError = DataError.Remote.NO_RESULTS,
             ) { }
         }
 
@@ -112,7 +110,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(resultError = com.nacchofer31.randomboxd.core.domain.DataError.Remote.NO_INTERNET),
+                resultError = DataError.Remote.NO_INTERNET,
             ) { }
         }
 
@@ -125,7 +123,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(userNameSearchList = setOf("user1", "user2")),
+                userNameSearchList = setOf("user1", "user2"),
             ) { }
         }
 
@@ -148,15 +146,12 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state =
-                    RandomFilmState(
-                        resultFilm =
-                            Film(
-                                slug = "test-slug",
-                                name = "test-name",
-                                releaseYear = null,
-                                imageUrl = "test-image-url",
-                            ),
+                resultFilm =
+                    Film(
+                        slug = "test-slug",
+                        name = "test-name",
+                        releaseYear = null,
+                        imageUrl = "test-image-url",
                     ),
             ) { }
         }
@@ -170,7 +165,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(resultError = com.nacchofer31.randomboxd.core.domain.DataError.Remote.UNKNOWN),
+                resultError = DataError.Remote.UNKNOWN,
             ) { }
         }
 
@@ -183,7 +178,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(showGenreBottomSheet = true),
+                showGenreBottomSheet = true,
             ) { }
         }
 
@@ -196,7 +191,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(showGenreBottomSheet = false),
+                showGenreBottomSheet = false,
             ) { }
         }
 
@@ -209,7 +204,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(selectedGenres = setOf(FilmGenre.ACTION, FilmGenre.COMEDY)),
+                selectedGenres = setOf(FilmGenre.ACTION, FilmGenre.COMEDY),
             ) { }
         }
 
@@ -222,7 +217,7 @@ class RandomFilmScreenTest {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
             RandomFilmScreen(
                 userNameList = mutableUserNamesFlow,
-                state = RandomFilmState(selectedGenres = emptySet()),
+                selectedGenres = emptySet(),
             ) { }
         }
 

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
@@ -12,14 +12,18 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nacchofer31.randomboxd.core.domain.DataError
 import com.nacchofer31.randomboxd.core.presentation.RandomBoxdColors
 import com.nacchofer31.randomboxd.random_film.domain.model.Film
+import com.nacchofer31.randomboxd.random_film.domain.model.FilmGenre
+import com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode
 import com.nacchofer31.randomboxd.random_film.domain.model.UserName
 import com.nacchofer31.randomboxd.random_film.presentation.components.ActionRow
 import com.nacchofer31.randomboxd.random_film.presentation.components.FilmDisplay
@@ -31,9 +35,10 @@ import com.nacchofer31.randomboxd.random_film.presentation.components.RandomFilm
 import com.nacchofer31.randomboxd.random_film.presentation.components.UnionIntersectionSwitch
 import com.nacchofer31.randomboxd.random_film.presentation.components.UserNameTagListView
 import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmAction
-import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmState
 import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -42,33 +47,59 @@ fun RandomFilmScreenRoot(
     onFilmClicked: (Film) -> Unit,
     onInfoClick: () -> Unit = {},
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val stateFlow = viewModel.state
+    val isLoading by stateFlow.map { it.isLoading }.collectAsStateWithLifecycle(initialValue = false)
+    val resultFilm by stateFlow.map { it.resultFilm }.collectAsStateWithLifecycle(initialValue = null)
+    val resultError by stateFlow.map { it.resultError }.collectAsStateWithLifecycle(initialValue = null)
+    val userName by stateFlow.map { it.userName }.collectAsStateWithLifecycle(initialValue = "")
+    val userNameSearchList by stateFlow.map { it.userNameSearchList }.collectAsStateWithLifecycle(initialValue = emptySet())
+    val filmSearchMode by stateFlow.map { it.filmSearchMode }.collectAsStateWithLifecycle(initialValue = FilmSearchMode.INTERSECTION)
+    val selectedGenres by stateFlow.map { it.selectedGenres }.collectAsStateWithLifecycle(initialValue = emptySet())
+    val showGenreBottomSheet by stateFlow.map { it.showGenreBottomSheet }.collectAsStateWithLifecycle(initialValue = false)
 
-    RandomFilmScreen(
-        state = state,
-        userNameList = viewModel.userNameList,
-        onAction = { action ->
+    val onAction = remember(viewModel, onFilmClicked, onInfoClick) {
+        { action: RandomFilmAction ->
             when (action) {
                 is RandomFilmAction.OnFilmClicked -> onFilmClicked(action.film)
                 is RandomFilmAction.OnInfoButtonClick -> onInfoClick()
                 else -> Unit
             }
             viewModel.onAction(action)
-        },
+        }
+    }
+
+    RandomFilmScreen(
+        isLoading = isLoading,
+        resultFilm = resultFilm,
+        resultError = resultError,
+        userName = userName,
+        userNameSearchList = userNameSearchList,
+        filmSearchMode = filmSearchMode,
+        selectedGenres = selectedGenres,
+        showGenreBottomSheet = showGenreBottomSheet,
+        userNameList = viewModel.userNameList,
+        onAction = onAction,
     )
 }
 
 @Composable
 fun RandomFilmScreen(
-    state: RandomFilmState,
-    userNameList: StateFlow<List<UserName>>,
-    onAction: (RandomFilmAction) -> Unit,
+    isLoading: Boolean = false,
+    resultFilm: Film? = null,
+    resultError: DataError.Remote? = null,
+    userName: String = "",
+    userNameSearchList: Set<String> = emptySet(),
+    filmSearchMode: FilmSearchMode = FilmSearchMode.INTERSECTION,
+    selectedGenres: Set<FilmGenre> = emptySet(),
+    showGenreBottomSheet: Boolean = false,
+    userNameList: StateFlow<List<UserName>> = MutableStateFlow(emptyList()),
+    onAction: (RandomFilmAction) -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
 
-    if (state.showGenreBottomSheet) {
+    if (showGenreBottomSheet) {
         GenreFilterBottomSheet(
-            selectedGenres = state.selectedGenres,
+            selectedGenres = selectedGenres,
             onApply = { genres -> onAction(RandomFilmAction.OnGenreSelectionApplied(genres)) },
             onDismiss = { onAction(RandomFilmAction.OnGenreBottomSheetDismiss) },
         )
@@ -77,7 +108,7 @@ fun RandomFilmScreen(
     Scaffold(
         topBar = {
             FilmHeader(
-                showInfoButton = !state.isLoading,
+                showInfoButton = !isLoading,
                 onInfoClick = {
                     onAction(RandomFilmAction.OnInfoButtonClick)
                 },
@@ -104,14 +135,14 @@ fun RandomFilmScreen(
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    state.resultError?.let {
+                    resultError?.let {
                         FilmErrorView(it)
                     }
-                    state.resultFilm?.takeIf { !state.isLoading }?.let {
+                    resultFilm?.takeIf { !isLoading }?.let {
                         FilmDisplay(it, onAction)
-                    } ?: LoadingOrPrompt(state)
+                    } ?: LoadingOrPrompt(isLoading)
 
-                    if (state.resultError == null && state.resultFilm == null && !state.isLoading) {
+                    if (resultError == null && resultFilm == null && !isLoading) {
                         RandomFilmInfoView()
                     }
                 }
@@ -121,23 +152,23 @@ fun RandomFilmScreen(
                 ) {
                     UserNameTagListView(
                         userNameList = userNameList,
-                        userNameSearchList = state.userNameSearchList,
-                        fimSearchMode = state.filmSearchMode,
+                        userNameSearchList = userNameSearchList,
+                        fimSearchMode = filmSearchMode,
                         onAction = onAction,
                     )
                     ActionRow(
-                        state.userName,
-                        state.userNameSearchList,
-                        state.isLoading,
+                        userName,
+                        userNameSearchList,
+                        isLoading,
                         focusManager,
                         onAction,
-                        state.filmSearchMode,
-                        state.selectedGenres,
+                        filmSearchMode,
+                        selectedGenres,
                     ) { onAction(RandomFilmAction.OnUserNameChanged(it)) }
-                    if (state.userNameSearchList.isNotEmpty()) {
+                    if (userNameSearchList.isNotEmpty()) {
                         UnionIntersectionSwitch(
                             modifier = Modifier.padding(top = 10.dp),
-                            searchMode = state.filmSearchMode,
+                            searchMode = filmSearchMode,
                             onModeChange = {
                                 onAction(RandomFilmAction.OnFilmSearchModeToggle)
                             },

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
@@ -57,16 +57,17 @@ fun RandomFilmScreenRoot(
     val selectedGenres by stateFlow.map { it.selectedGenres }.collectAsStateWithLifecycle(initialValue = emptySet())
     val showGenreBottomSheet by stateFlow.map { it.showGenreBottomSheet }.collectAsStateWithLifecycle(initialValue = false)
 
-    val onAction = remember(viewModel, onFilmClicked, onInfoClick) {
-        { action: RandomFilmAction ->
-            when (action) {
-                is RandomFilmAction.OnFilmClicked -> onFilmClicked(action.film)
-                is RandomFilmAction.OnInfoButtonClick -> onInfoClick()
-                else -> Unit
+    val onAction =
+        remember(viewModel, onFilmClicked, onInfoClick) {
+            { action: RandomFilmAction ->
+                when (action) {
+                    is RandomFilmAction.OnFilmClicked -> onFilmClicked(action.film)
+                    is RandomFilmAction.OnInfoButtonClick -> onInfoClick()
+                    else -> Unit
+                }
+                viewModel.onAction(action)
             }
-            viewModel.onAction(action)
         }
-    }
 
     RandomFilmScreen(
         isLoading = isLoading,

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/LoadingOrPrompt.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/LoadingOrPrompt.kt
@@ -16,15 +16,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nacchofer31.randomboxd.core.presentation.RandomBoxdColors
 import com.nacchofer31.randomboxd.core.presentation.components.loading.RandomBoxdLoadingDiceView
-import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmState
 import org.jetbrains.compose.resources.stringResource
 import randomboxd.composeapp.generated.resources.Res
 import randomboxd.composeapp.generated.resources.finding_random_movie
 import randomboxd.composeapp.generated.resources.rolling_the_dice
 
 @Composable
-internal fun LoadingOrPrompt(state: RandomFilmState) {
-    if (state.isLoading) {
+internal fun LoadingOrPrompt(isLoading: Boolean) {
+    if (isLoading) {
         return Column(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {


### PR DESCRIPTION
## Summary
Refactored `RandomFilmScreen` to reduce unnecessary recompositions by splitting the monolithic `RandomFilmState` read into individual field subscriptions and stabilizing the `onAction` callback.
## Changes
### `RandomFilmScreenRoot`
- Replaced single `collectAsStateWithLifecycle()` on the entire `RandomFilmState` with individual `stateFlow.map { it.field }.collectAsStateWithLifecycle()` calls per field
- This ensures that changes to one field (e.g. `userName` on every keystroke) only recompose components that actually read that field, instead of the entire screen
- Wrapped `onAction` lambda in `remember(viewModel, onFilmClicked, onInfoClick)` to stabilize its identity across recompositions, preventing child components from recomposing due to lambda identity changes
### `RandomFilmScreen`
- Changed signature from receiving a single `state: RandomFilmState` to individual parameters with default values
- Makes the composable easier to test and preview in isolation
### `LoadingOrPrompt`
- Simplified from `LoadingOrPrompt(state: RandomFilmState)` to `LoadingOrPrompt(isLoading: Boolean)` to reduce coupling
### Tests
- Updated `LoadingOrPromptTest` and `RandomFilmScreenTest` to match the new component APIs