### PR TITLE
feat: Added animated dots to loading text and optimize dice animation performance

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/LoadingOrPromptTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/LoadingOrPromptTest.kt
@@ -39,7 +39,7 @@ class LoadingOrPromptTest {
             LoadingOrPrompt(isLoading = true)
         }
 
-        composeTestRule.onNodeWithText("Rolling the dice...").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Rolling the dice", substring = true).assertIsDisplayed()
     }
 
     @Test

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/core/presentation/components/loading/RandomBoxdLoadingView.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/core/presentation/components/loading/RandomBoxdLoadingView.kt
@@ -1,6 +1,7 @@
 package com.nacchofer31.randomboxd.core.presentation.components.loading
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
@@ -16,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.nacchofer31.randomboxd.core.presentation.RandomBoxdColors
 import kotlinx.coroutines.delay
@@ -26,11 +28,13 @@ fun RandomBoxdLoadingDiceView(
     modifier: Modifier = Modifier,
 ) {
     val dice =
-        listOf(
-            DiceData(color = RandomBoxdColors.OrangeAccent),
-            DiceData(color = RandomBoxdColors.GreenAccent),
-            DiceData(color = RandomBoxdColors.BlueAccent),
-        )
+        remember {
+            listOf(
+                DiceData(color = RandomBoxdColors.OrangeAccent),
+                DiceData(color = RandomBoxdColors.GreenAccent),
+                DiceData(color = RandomBoxdColors.BlueAccent),
+            )
+        }
 
     val offsetAnim = remember { Animatable(0f) }
     val rotationAnim = remember { Animatable(0f) }
@@ -65,8 +69,8 @@ fun RandomBoxdLoadingDiceView(
         dice.forEachIndexed { index, die ->
             RandomBoxdLoadingViewDice(
                 die = die,
-                offset = offsetAnim.value,
-                rotation = rotationAnim.value,
+                offsetAnim = offsetAnim,
+                rotationAnim = rotationAnim,
                 face = currentFaces[index],
             )
         }
@@ -76,17 +80,17 @@ fun RandomBoxdLoadingDiceView(
 @Composable
 fun RandomBoxdLoadingViewDice(
     die: DiceData,
-    offset: Float,
-    rotation: Float,
+    offsetAnim: Animatable<Float, AnimationVector1D>,
+    rotationAnim: Animatable<Float, AnimationVector1D>,
     face: Int,
 ) {
     Canvas(
         modifier =
             Modifier
                 .size(56.dp)
-                .offset(y = offset.dp),
+                .offset { IntOffset(0, offsetAnim.value.toInt()) },
     ) {
-        rotate(rotation) {
+        rotate(rotationAnim.value) {
             drawRoundRect(
                 color = die.color,
                 size = size,

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/LoadingOrPrompt.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/LoadingOrPrompt.kt
@@ -7,15 +7,23 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nacchofer31.randomboxd.core.presentation.RandomBoxdColors
 import com.nacchofer31.randomboxd.core.presentation.components.loading.RandomBoxdLoadingDiceView
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import randomboxd.composeapp.generated.resources.Res
 import randomboxd.composeapp.generated.resources.finding_random_movie
@@ -31,10 +39,9 @@ internal fun LoadingOrPrompt(isLoading: Boolean) {
                 modifier = Modifier.padding(vertical = 30.dp).testTag("test-loading-indicator"),
             )
             Spacer(modifier = Modifier.height(10.dp))
-            Text(
-                stringResource(Res.string.rolling_the_dice),
+            AnimatedDotsText(
+                baseText = stringResource(Res.string.rolling_the_dice),
                 color = RandomBoxdColors.White,
-                textAlign = TextAlign.Center,
                 fontSize = 26.sp,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.fillMaxWidth(),
@@ -50,4 +57,32 @@ internal fun LoadingOrPrompt(isLoading: Boolean) {
             )
         }
     }
+}
+
+@Composable
+private fun AnimatedDotsText(
+    baseText: String,
+    color: Color,
+    fontSize: TextUnit,
+    fontWeight: FontWeight,
+    modifier: Modifier = Modifier,
+) {
+    val cleanText = remember(baseText) { baseText.trimEnd { it == '.' } }
+    var dotCount by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            dotCount = (dotCount + 1) % 4
+            delay(500)
+        }
+    }
+
+    Text(
+        text = "$cleanText${".".repeat(dotCount)}",
+        color = color,
+        textAlign = TextAlign.Center,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        modifier = modifier,
+    )
 }


### PR DESCRIPTION
## Summary

Optimized loading animation performance and added animated dots to the "Rolling the dice..." text.

## Changes

### `RandomBoxdLoadingView.kt`
- Wrapped `dice` list in `remember` to avoid recreation on every composition
- Changed `offsetAnim.value` to be read inside `Modifier.offset { IntOffset(...) }` lambda — triggers only layout invalidation, not full recomposition
- Changed `rotationAnim.value` to be read inside the Canvas `rotate { }` draw block — triggers only redraw, no layout or recomposition
- `RandomBoxdLoadingViewDice` now receives `Animatable` references instead of `Float` values, deferring the `.value` reads to layout/draw lambdas

**Before:** each animation frame (~60fps) recomposed `RandomBoxdLoadingDiceView` + all 3 child composables.  
**After:** each frame only invalidates layout + redraw of individual Canvas elements, with zero recomposition.

### `LoadingOrPrompt.kt`
- Added `AnimatedDotsText` composable that cycles through 0 → 1 → 2 → 3 dots every 500ms on the "Rolling the dice" text
- Fixed `LoadingOrPromptTest` to use `substring = true` instead of exact text match, avoiding flaky failures during the dot animation cycle