### PR TITLE
 refactor(ui): migrate username field to state-based TextField

### DIFF
--- a/.opencode/commands/autocommit.md
+++ b/.opencode/commands/autocommit.md
@@ -1,0 +1,43 @@
+---
+description: Add git files and write proper commit messages
+agent: build
+---
+
+## The Git Automator Prompt
+
+**Role:** You are an expert Git Assistant specializing in repository maintenance and atomic commits. Your goal is to take a large, unorganized diff and transform it into a series of clean, logical, and well-documented commits.
+
+You must commit the changes in the current directory only.
+
+**Your Workflow:**
+
+1. **Analyze the Diff:** Run `git diff .` and `git diff --cached .` to understand the scope of the changes.
+2. **Identify Logical Units:** Group changes by functionality (e.g., a bug fix in one file, a new feature in another, and a refactor in a third).
+3. **Selective Staging:** Use `git add -p` or specific file paths to stage only the changes belonging to a single logical unit.
+4. **Draft Commit Messages:** Create a message following the **Conventional Commits** specification:
+* **Format:** `<type>(<scope>): <description>`
+* **Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+* **Body:** Provide a brief explanation of *why* the change was made if the diff is complex.
+
+
+**Execute & Repeat:** Commit the staged changes and repeat the process until the working directory is clean.
+
+**Constraints:**
+
+* Never commit unrelated changes together.
+* Keep the subject line under **50 characters**.
+* Use the imperative mood (e.g., "add feature" instead of "added feature").
+* If a change spans multiple files but represents one "feature," commit them together.
+
+---
+
+### Example Execution Logic
+
+When you trigger this command, the agent will essentially perform a loop like this:
+
+| Step | Action | Command Example |
+| --- | --- | --- |
+| **1** | **Scan** | `git diff --stat` |
+| **2** | **Isolate** | `git add -p [file_name]` (Interactive selection of hunks) |
+| **3** | **Commit** | `git commit -m "feat(auth): add JWT validation logic"` |
+| **4** | **Verify** | `git status` (Ensure no relevant diffs remain) |

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
@@ -8,11 +8,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -38,6 +42,7 @@ import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmA
 import com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -57,6 +62,13 @@ fun RandomFilmScreenRoot(
     val selectedGenres by stateFlow.map { it.selectedGenres }.collectAsStateWithLifecycle(initialValue = emptySet())
     val showGenreBottomSheet by stateFlow.map { it.showGenreBottomSheet }.collectAsStateWithLifecycle(initialValue = false)
 
+    val usernameState = rememberTextFieldState(userName)
+    LaunchedEffect(usernameState) {
+        snapshotFlow { usernameState.text.toString() }.collectLatest {
+            viewModel.onAction(RandomFilmAction.OnUserNameChanged(it))
+        }
+    }
+
     val onAction =
         remember(viewModel, onFilmClicked, onInfoClick) {
             { action: RandomFilmAction ->
@@ -73,7 +85,7 @@ fun RandomFilmScreenRoot(
         isLoading = isLoading,
         resultFilm = resultFilm,
         resultError = resultError,
-        userName = userName,
+        usernameState = usernameState,
         userNameSearchList = userNameSearchList,
         filmSearchMode = filmSearchMode,
         selectedGenres = selectedGenres,
@@ -88,7 +100,7 @@ fun RandomFilmScreen(
     isLoading: Boolean = false,
     resultFilm: Film? = null,
     resultError: DataError.Remote? = null,
-    userName: String = "",
+    usernameState: TextFieldState = TextFieldState(""),
     userNameSearchList: Set<String> = emptySet(),
     filmSearchMode: FilmSearchMode = FilmSearchMode.INTERSECTION,
     selectedGenres: Set<FilmGenre> = emptySet(),
@@ -160,14 +172,14 @@ fun RandomFilmScreen(
                         onAction = onAction,
                     )
                     ActionRow(
-                        userName,
+                        usernameState,
                         userNameSearchList,
                         isLoading,
                         focusManager,
                         onAction,
                         filmSearchMode,
                         selectedGenres,
-                    ) { onAction(RandomFilmAction.OnUserNameChanged(it)) }
+                    )
                     if (userNameSearchList.isNotEmpty()) {
                         UnionIntersectionSwitch(
                             modifier = Modifier.padding(top = 10.dp),

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/ActionRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/ActionRow.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material3.Icon
@@ -36,14 +38,13 @@ import randomboxd.composeapp.generated.resources.submit
 
 @Composable
 internal fun ActionRow(
-    userName: String,
+    usernameState: TextFieldState,
     userNameSearchList: Set<String>,
     isLoading: Boolean,
     focusManager: FocusManager,
     onAction: (RandomFilmAction) -> Unit,
     filmSearchMode: FilmSearchMode?,
     selectedGenres: Set<FilmGenre>,
-    onUserNameChange: (String) -> Unit,
 ) = Row(
     horizontalArrangement = Arrangement.Center,
     modifier = Modifier.height(56.dp),
@@ -100,7 +101,7 @@ internal fun ActionRow(
     }
 
     UserNameTextField(
-        value = userName,
+        state = usernameState,
         hint =
             if (userNameSearchList.isNotEmpty()) {
                 if (userNameSearchList.size > 1) {
@@ -111,14 +112,14 @@ internal fun ActionRow(
             } else {
                 null
             },
-        onChange = onUserNameChange,
         onRemoveButtonClick = {
-            onUserNameChange("")
+            usernameState.setTextAndPlaceCursorAtEnd("")
             onAction(RandomFilmAction.OnClearButtonClick)
         },
         modifier = Modifier.weight(1f).testTag("test-random-film-user-name-text-field"),
     )
 
+    val userName = usernameState.text.toString()
     val enabled = (userName.trim().isNotEmpty() || userNameSearchList.isNotEmpty()) && !isLoading
 
     Surface(
@@ -139,7 +140,7 @@ internal fun ActionRow(
                     onLongClick = {
                         if (userName.trim().isNotEmpty()) {
                             focusManager.clearFocus()
-                            onUserNameChange("")
+                            usernameState.setTextAndPlaceCursorAtEnd("")
                             onAction(RandomFilmAction.OnClearButtonClick)
                             onAction(RandomFilmAction.OnUserNameAdded(userName))
                             onAction(RandomFilmAction.OnAddOrRemoveUserNameSearchList(userName))

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/UserNameTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/UserNameTextField.kt
@@ -3,6 +3,8 @@ package com.nacchofer31.randomboxd.random_film.presentation.components
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material.icons.Icons
@@ -28,8 +30,7 @@ import randomboxd.composeapp.generated.resources.enter_your_user_name
 
 @Composable
 fun UserNameTextField(
-    value: String,
-    onChange: (String) -> Unit,
+    state: TextFieldState,
     modifier: Modifier = Modifier,
     hint: String?,
     onRemoveButtonClick: () -> Unit,
@@ -41,8 +42,8 @@ fun UserNameTextField(
         ),
 ) {
     TextField(
-        value = value,
-        onValueChange = onChange,
+        state = state,
+        lineLimits = TextFieldLineLimits.SingleLine,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
         placeholder = {
             Text(
@@ -53,7 +54,6 @@ fun UserNameTextField(
             )
         },
         shape = RoundedCornerShape(topStart = 10.dp, bottomStart = 10.dp),
-        singleLine = true,
         colors =
             TextFieldDefaults.colors(
                 focusedIndicatorColor = Color.Transparent,
@@ -70,7 +70,11 @@ fun UserNameTextField(
             ),
         modifier = modifier,
         trailingIcon =
-            if (value.trim().isNotEmpty()) {
+            if (state.text
+                    .toString()
+                    .trim()
+                    .isNotEmpty()
+            ) {
                 {
                     IconButton(
                         onClick = onRemoveButtonClick,


### PR DESCRIPTION
- Replace value/onValueChange pattern with TextFieldState and TextFieldLineLimits.SingleLine in UserNameTextField
- Update ActionRow to receive TextFieldState, read text directly for submit logic, and clear via setTextAndPlaceCursorAtEnd
- Add conforming approach in RandomFilmScreenRoot: rememberTextFieldState + snapshotFlow syncs back to ViewModel without changing ViewModel internals