### PR TITLE
fix(random-film): sync TextFieldState with ViewModel on chip updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ freeline_project_description.json
 
 # Claude
 .claude/
+
+# ATL (AI tooling local config)
+.atl/

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/RandomFilmScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -62,7 +62,16 @@ fun RandomFilmScreenRoot(
     val selectedGenres by stateFlow.map { it.selectedGenres }.collectAsStateWithLifecycle(initialValue = emptySet())
     val showGenreBottomSheet by stateFlow.map { it.showGenreBottomSheet }.collectAsStateWithLifecycle(initialValue = false)
 
-    val usernameState = rememberTextFieldState(userName)
+    val usernameState = remember { TextFieldState(userName) }
+
+    // Sync ViewModel → TextFieldState: chip clicks, clear, external changes
+    LaunchedEffect(userName) {
+        if (usernameState.text.toString() != userName) {
+            usernameState.setTextAndPlaceCursorAtEnd(userName)
+        }
+    }
+
+    // Sync TextFieldState → ViewModel: keyboard input
     LaunchedEffect(usernameState) {
         snapshotFlow { usernameState.text.toString() }.collectLatest {
             viewModel.onAction(RandomFilmAction.OnUserNameChanged(it))


### PR DESCRIPTION
**Description:**
## Problem
`rememberTextFieldState` created a new state instance on every recomposition,
losing the sync between the ViewModel and the text field when genre chips updated
the username externally.

## Changes
- Replace `rememberTextFieldState` with `remember { TextFieldState(...) }` to
  preserve the instance across recompositions
- Add `LaunchedEffect(userName)` to push ViewModel changes (chip clicks, clear)
  into the TextFieldState via `setTextAndPlaceCursorAtEnd`
- Add `.atl/` to `.gitignore` (local AI tooling config)