### PR TITLE
feat(reroll): add reroll button to pick another random film

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/FilmPosterTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/FilmPosterTest.kt
@@ -55,6 +55,7 @@ class FilmPosterTest {
                 title = "Test Film",
                 releaseYear = "2020",
                 onClick = {},
+                onRerollClick = {},
             )
         }
 
@@ -80,6 +81,7 @@ class FilmPosterTest {
                 title = "Test Film",
                 releaseYear = "2020",
                 onClick = {},
+                onRerollClick = {},
             )
         }
 
@@ -105,6 +107,7 @@ class FilmPosterTest {
                 title = "Inception",
                 releaseYear = "2010",
                 onClick = { clicked = true },
+                onRerollClick = {},
             )
         }
 

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
@@ -278,7 +278,7 @@ class RandomFilmScreenTest {
                 false
             }
         }
-        
+
         composeTestRule.onNodeWithTag("test-film-poster").performClick()
         assert(filmClicked)
     }

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
@@ -244,7 +244,7 @@ class RandomFilmScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Reroll").performClick()
+        composeTestRule.onNodeWithTag("test-reroll-button").performClick()
         assert(rerollClicked)
     }
 
@@ -269,6 +269,16 @@ class RandomFilmScreenTest {
             }
         }
 
+        // Wait for the poster to be displayed and click it
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            try {
+                composeTestRule.onNodeWithTag("test-film-poster").assertExists()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+        
         composeTestRule.onNodeWithTag("test-film-poster").performClick()
         assert(filmClicked)
     }

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
@@ -1,5 +1,6 @@
 package com.randomboxd.feature.random_film.presentation
 
+import android.graphics.Bitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -10,6 +11,12 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.annotation.DelicateCoilApi
+import coil3.asImage
+import coil3.test.FakeImageLoaderEngine
 import com.nacchofer31.randomboxd.core.domain.DataError
 import com.nacchofer31.randomboxd.random_film.domain.model.Film
 import com.nacchofer31.randomboxd.random_film.domain.model.FilmGenre
@@ -17,6 +24,7 @@ import com.nacchofer31.randomboxd.random_film.domain.model.UserName
 import com.nacchofer31.randomboxd.random_film.presentation.RandomFilmScreen
 import com.nacchofer31.randomboxd.random_film.presentation.RandomFilmScreenRoot
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,6 +33,20 @@ import org.junit.runner.RunWith
 class RandomFilmScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @After
+    @OptIn(DelicateCoilApi::class)
+    fun resetImageLoader() {
+        SingletonImageLoader.reset()
+    }
+
+    private fun setImageLoader(engine: FakeImageLoaderEngine) {
+        SingletonImageLoader.setSafe {
+            ImageLoader.Builder(context).components { add(engine) }.build()
+        }
+    }
 
     @Test
     fun all_random_film_screen_initial_components_should_be_displayed() {
@@ -225,6 +247,14 @@ class RandomFilmScreenTest {
 
     @Test
     fun reroll_button_click_triggers_reroll_action() {
+        val bitmap = Bitmap.createBitmap(200, 200, Bitmap.Config.ARGB_8888)
+        setImageLoader(
+            FakeImageLoaderEngine
+                .Builder()
+                .default(bitmap.asImage())
+                .build(),
+        )
+
         var rerollClicked = false
         composeTestRule.setContent {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
@@ -244,12 +274,21 @@ class RandomFilmScreenTest {
             }
         }
 
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("test-reroll-button").performClick()
         assert(rerollClicked)
     }
 
     @Test
     fun film_poster_click_triggers_film_clicked_action() {
+        val bitmap = Bitmap.createBitmap(200, 200, Bitmap.Config.ARGB_8888)
+        setImageLoader(
+            FakeImageLoaderEngine
+                .Builder()
+                .default(bitmap.asImage())
+                .build(),
+        )
+
         var filmClicked = false
         composeTestRule.setContent {
             val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
@@ -269,16 +308,7 @@ class RandomFilmScreenTest {
             }
         }
 
-        // Wait for the poster to be displayed and click it
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            try {
-                composeTestRule.onNodeWithTag("test-film-poster").assertExists()
-                true
-            } catch (e: AssertionError) {
-                false
-            }
-        }
-
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("test-film-poster").performClick()
         assert(filmClicked)
     }

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/randomboxd/feature/random_film/presentation/RandomFilmScreenTest.kt
@@ -222,4 +222,54 @@ class RandomFilmScreenTest {
 
         composeTestRule.onNodeWithTag("test-random-film-genre-badge").assertDoesNotExist()
     }
+
+    @Test
+    fun reroll_button_click_triggers_reroll_action() {
+        var rerollClicked = false
+        composeTestRule.setContent {
+            val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
+            RandomFilmScreen(
+                userNameList = mutableUserNamesFlow,
+                resultFilm =
+                    Film(
+                        slug = "test-slug",
+                        name = "test-name",
+                        releaseYear = 2000,
+                        imageUrl = "test-image-url",
+                    ),
+            ) { action ->
+                if (action is com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmAction.OnRerollClicked) {
+                    rerollClicked = true
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("Reroll").performClick()
+        assert(rerollClicked)
+    }
+
+    @Test
+    fun film_poster_click_triggers_film_clicked_action() {
+        var filmClicked = false
+        composeTestRule.setContent {
+            val mutableUserNamesFlow = MutableStateFlow<List<UserName>>(emptyList())
+            RandomFilmScreen(
+                userNameList = mutableUserNamesFlow,
+                resultFilm =
+                    Film(
+                        slug = "test-slug",
+                        name = "test-name",
+                        releaseYear = 2000,
+                        imageUrl = "test-image-url",
+                    ),
+            ) { action ->
+                if (action is com.nacchofer31.randomboxd.random_film.presentation.viewmodel.RandomFilmAction.OnFilmClicked) {
+                    filmClicked = true
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag("test-film-poster").performClick()
+        assert(filmClicked)
+    }
 }

--- a/composeApp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ar/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">يعمل مع وضع المستخدم الواحد ووضع متعدد المستخدمين</string>
     <string name="rolling_the_dice">جاري رمي النرد...</string>
     <string name="finding_random_movie">جاري البحث عن فيلمك العشوائي</string>
+    <string name="reroll">إعادة الرمي</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Funciona amb els modes d\'un sol usuari i multiusuari</string>
     <string name="rolling_the_dice">Llançant els daus...</string>
     <string name="finding_random_movie">Trobar la teva pel·lícula aleatòria</string>
+    <string name="reroll">Tornar a tirar</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Funktioniert im Einzel- und Mehrbenutzermodus</string>
     <string name="rolling_the_dice">Würfel rollen...</string>
     <string name="finding_random_movie">Finde deinen zufälligen Film</string>
+    <string name="reroll">Neu würfeln</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Funciona con los modos de un solo usuario y multiusuario</string>
     <string name="rolling_the_dice">Lanzando los dados...</string>
     <string name="finding_random_movie">Encontrando tu película aleatoria</string>
+    <string name="reroll">Tirar de nuevo</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Fonctionne avec les modes utilisateur unique et multi-utilisateur</string>
     <string name="rolling_the_dice">Lancement des dés...</string>
     <string name="finding_random_movie">Trouver votre film aléatoire</string>
+    <string name="reroll">Relancer</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-gl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-gl/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Funciona cos modos de usuario único e multiusuario</string>
     <string name="rolling_the_dice">Lanzando os dados...</string>
     <string name="finding_random_movie">Atopando o teu filme aleatorio</string>
+    <string name="reroll">Tirar de novo</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-hi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-hi/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">एकल उपयोगकर्ता और बहु-उपयोगकर्ता मोड दोनों के साथ काम करता है</string>
     <string name="rolling_the_dice">पासा फेंक रहे हैं...</string>
     <string name="finding_random_movie">आपकी यादृच्छिक फिल्म खोज रहे हैं</string>
+    <string name="reroll">फिर से फेंकें</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Funziona con le modalità utente singolo e multiutente</string>
     <string name="rolling_the_dice">Lanciando i dadi...</string>
     <string name="finding_random_movie">Trovare il tuo film casuale</string>
+    <string name="reroll">Rilancia</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">シングルユーザーとマルチユーザーモードの両方で動作</string>
     <string name="rolling_the_dice">サイコロを振っています...</string>
     <string name="finding_random_movie">ランダム映画を探しています</string>
+    <string name="reroll">もう一度振る</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Funciona nos modos de usuário único e multiusuário</string>
     <string name="rolling_the_dice">Lançando os dados...</string>
     <string name="finding_random_movie">Encontrando seu filme aleatório</string>
+    <string name="reroll">Rolar novamente</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Работает в режимах одного и нескольких пользователей</string>
     <string name="rolling_the_dice">Бросаем кубики...</string>
     <string name="finding_random_movie">Ищем ваш случайный фильм</string>
+    <string name="reroll">Перебросить</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">适用于单用户和多用户模式</string>
     <string name="rolling_the_dice">掷骰子中...</string>
     <string name="finding_random_movie">正在寻找您的随机电影</string>
+    <string name="reroll">重新掷骰</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -70,4 +70,5 @@
     <string name="onboarding_genre_feature3">Works with single user and multi-user modes</string>
     <string name="rolling_the_dice">Rolling the dice...</string>
     <string name="finding_random_movie">Finding your random movie</string>
+    <string name="reroll">Reroll</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/data/repository_impl/RandomFilmScrappingRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/data/repository_impl/RandomFilmScrappingRepository.kt
@@ -35,29 +35,27 @@ class RandomFilmScrappingRepository(
         const val FILM_SCRIPT_QUERY = """script[type="application/ld+json"]"""
     }
 
-    override suspend fun getRandomMovie(
+    override suspend fun getRandomMovies(
         userName: String,
         selectedGenres: Set<FilmGenre>,
-    ): ResultData<Film, DataError.Remote> =
+    ): ResultData<Set<Film>, DataError.Remote> =
         withContext(Dispatchers.IO) {
-            val filmsResult = getFilmsFromUserWatchlist(userName, selectedGenres)
             val films =
-                when (filmsResult) {
+                when (val filmsResult = getFilmsFromUserWatchlist(userName, selectedGenres)) {
                     is ResultData.Success -> filmsResult.data
                     is ResultData.Error -> return@withContext ResultData.Error(filmsResult.error)
                 }
 
             if (films.isEmpty()) return@withContext ResultData.Error(DataError.Remote.NO_RESULTS)
 
-            val chosenFilm = films.random()
-            extractFilm(chosenFilm)
+            return@withContext ResultData.Success(films.toSet())
         }
 
     override suspend fun getRandomMoviesFromSearchList(
         searchList: Set<String>,
         filmSearchMode: FilmSearchMode,
         selectedGenres: Set<FilmGenre>,
-    ): ResultData<Film, DataError.Remote> =
+    ): ResultData<Set<Film>, DataError.Remote> =
         withContext(Dispatchers.IO) {
             if (searchList.isEmpty()) return@withContext ResultData.Error(DataError.Remote.SERIALIZATION)
 
@@ -88,9 +86,10 @@ class RandomFilmScrappingRepository(
 
             if (combinedFilms.isEmpty()) return@withContext ResultData.Error(DataError.Remote.NO_RESULTS)
 
-            val chosenFilm = combinedFilms.random()
-            extractFilm(chosenFilm)
+            return@withContext ResultData.Success(combinedFilms)
         }
+
+    override suspend fun extractResultMovie(film: Film): ResultData<Film, DataError.Remote> = extractFilm(film)
 
     private suspend fun getFilmsFromUserWatchlist(
         userName: String,
@@ -118,9 +117,8 @@ class RandomFilmScrappingRepository(
         val films = mutableListOf<Film>()
         for (page in 1..totalPages) {
             val pageUrl = "$baseUrl/page/$page/"
-            val htmlResult = getWebPage(pageUrl)
             val html =
-                when (htmlResult) {
+                when (val htmlResult = getWebPage(pageUrl)) {
                     is ResultData.Success -> htmlResult.data
                     is ResultData.Error -> return ResultData.Error(htmlResult.error)
                 }
@@ -157,9 +155,8 @@ class RandomFilmScrappingRepository(
     }
 
     private suspend fun extractFilm(film: Film): ResultData<Film, DataError.Remote> {
-        val posterResult = getPosterFromFilmPage(film.slug)
         val finalImageUrl =
-            when (posterResult) {
+            when (val posterResult = getPosterFromFilmPage(film.slug)) {
                 is ResultData.Success -> posterResult.data.ifEmpty { film.imageUrl }
                 is ResultData.Error -> film.imageUrl
             }
@@ -182,9 +179,8 @@ class RandomFilmScrappingRepository(
 
     private suspend fun getPosterFromFilmPage(slug: String): ResultData<String, DataError.Remote> {
         val url = RandomBoxdEndpoints.filmSlugUrl(slug)
-        val htmlResult = getWebPage(url)
         val html =
-            when (htmlResult) {
+            when (val htmlResult = getWebPage(url)) {
                 is ResultData.Success -> htmlResult.data
                 is ResultData.Error -> return ResultData.Error(htmlResult.error)
             }
@@ -207,9 +203,8 @@ class RandomFilmScrappingRepository(
     }
 
     private suspend fun getTotalPages(url: String): Int {
-        val htmlResult = getWebPage(url)
         val html =
-            when (htmlResult) {
+            when (val htmlResult = getWebPage(url)) {
                 is ResultData.Success -> htmlResult.data
                 is ResultData.Error -> return 1
             }

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/data/repository_impl/RandomFilmScrappingRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/data/repository_impl/RandomFilmScrappingRepository.kt
@@ -154,20 +154,23 @@ class RandomFilmScrappingRepository(
         return ResultData.Success(films)
     }
 
-    private suspend fun extractFilm(film: Film): ResultData<Film, DataError.Remote> {
-        val finalImageUrl =
-            when (val posterResult = getPosterFromFilmPage(film.slug)) {
-                is ResultData.Success -> posterResult.data.ifEmpty { film.imageUrl }
-                is ResultData.Error -> film.imageUrl
-            }
+    private suspend fun extractFilm(film: Film): ResultData<Film, DataError.Remote> =
+        try {
+            val finalImageUrl =
+                when (val posterResult = getPosterFromFilmPage(film.slug)) {
+                    is ResultData.Success -> posterResult.data.ifEmpty { film.imageUrl }
+                    is ResultData.Error -> film.imageUrl
+                }
 
-        return ResultData.Success(
-            film.copy(
-                imageUrl = finalImageUrl,
-                slug = RandomBoxdEndpoints.filmSlugUrl(film.slug),
-            ),
-        )
-    }
+            ResultData.Success(
+                film.copy(
+                    imageUrl = finalImageUrl,
+                    slug = RandomBoxdEndpoints.filmSlugUrl(film.slug),
+                ),
+            )
+        } catch (_: Exception) {
+            ResultData.Error(DataError.Remote.SERIALIZATION)
+        }
 
     private fun buildPosterUrl(
         filmId: String,

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/domain/repository/RandomFilmRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/domain/repository/RandomFilmRepository.kt
@@ -7,14 +7,18 @@ import com.nacchofer31.randomboxd.random_film.domain.model.FilmGenre
 import com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode
 
 interface RandomFilmRepository {
-    suspend fun getRandomMovie(
+    suspend fun getRandomMovies(
         userName: String,
         selectedGenres: Set<FilmGenre> = emptySet(),
-    ): ResultData<Film, DataError.Remote>
+    ): ResultData<Set<Film>, DataError.Remote>
 
     suspend fun getRandomMoviesFromSearchList(
         searchList: Set<String>,
         filmSearchMode: FilmSearchMode = FilmSearchMode.INTERSECTION,
         selectedGenres: Set<FilmGenre> = emptySet(),
+    ): ResultData<Set<Film>, DataError.Remote>
+
+    suspend fun extractResultMovie(
+        film: Film,
     ): ResultData<Film, DataError.Remote>
 }

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/FilmDisplay.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/FilmDisplay.kt
@@ -25,5 +25,8 @@ internal fun FilmDisplay(
         onClick = {
             onAction(RandomFilmAction.OnFilmClicked(film))
         },
+        onRerollClick = {
+            onAction(RandomFilmAction.OnRerollClicked)
+        },
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/FilmPoster.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/FilmPoster.kt
@@ -49,6 +49,7 @@ fun FilmPoster(
     title: String,
     releaseYear: String,
     onClick: () -> Unit,
+    onRerollClick: () -> Unit,
 ) {
     var imageLoadResult by remember {
         mutableStateOf<Result<Painter>?>(null)
@@ -167,6 +168,9 @@ fun FilmPoster(
                                 color = RandomBoxdColors.BackgroundLightColor,
                                 fontSize = 17.sp,
                                 textAlign = TextAlign.Center,
+                            )
+                            RerollButton(
+                                onClick = onRerollClick,
                             )
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RerollButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RerollButton.kt
@@ -1,0 +1,63 @@
+package com.nacchofer31.randomboxd.random_film.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.nacchofer31.randomboxd.core.presentation.RandomBoxdColors
+import org.jetbrains.compose.resources.stringResource
+import randomboxd.composeapp.generated.resources.Res
+import randomboxd.composeapp.generated.resources.reroll
+
+@Composable
+internal fun RerollButton(onClick: () -> Unit) =
+    Surface(
+        onClick = { onClick() },
+        modifier =
+            Modifier
+                .padding(top = 5.dp)
+                .dropShadow(
+                    shape = RoundedCornerShape(100),
+                    shadow =
+                        Shadow(
+                            radius = 10.dp,
+                            color = RandomBoxdColors.GreenAccent.copy(alpha = 0.25f),
+                            spread = 4.dp,
+                        ),
+                ),
+        shape = RoundedCornerShape(100),
+        color = RandomBoxdColors.GreenAccent,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 6.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Shuffle,
+                contentDescription = null,
+                tint = RandomBoxdColors.BackgroundDarkColor,
+                modifier = Modifier.size(20.dp),
+            )
+            Text(
+                text = stringResource(Res.string.reroll),
+                color = RandomBoxdColors.BackgroundDarkColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RerollButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RerollButton.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -38,7 +39,8 @@ internal fun RerollButton(onClick: () -> Unit) =
                             color = RandomBoxdColors.GreenAccent.copy(alpha = 0.25f),
                             spread = 4.dp,
                         ),
-                ),
+                )
+                .testTag("test-reroll-button"),
         shape = RoundedCornerShape(100),
         color = RandomBoxdColors.GreenAccent,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RerollButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RerollButton.kt
@@ -39,8 +39,7 @@ internal fun RerollButton(onClick: () -> Unit) =
                             color = RandomBoxdColors.GreenAccent.copy(alpha = 0.25f),
                             spread = 4.dp,
                         ),
-                )
-                .testTag("test-reroll-button"),
+                ).testTag("test-reroll-button"),
         shape = RoundedCornerShape(100),
         color = RandomBoxdColors.GreenAccent,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/viewmodel/RandomFilmAction.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/viewmodel/RandomFilmAction.kt
@@ -48,4 +48,6 @@ sealed interface RandomFilmAction {
     data class OnGenreSelectionApplied(
         val genres: Set<FilmGenre>,
     ) : RandomFilmAction
+
+    data object OnRerollClicked : RandomFilmAction
 }

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/viewmodel/RandomFilmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/viewmodel/RandomFilmViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nacchofer31.randomboxd.core.domain.DispatcherProvider
 import com.nacchofer31.randomboxd.core.domain.ResultData
+import com.nacchofer31.randomboxd.random_film.domain.model.Film
 import com.nacchofer31.randomboxd.random_film.domain.model.FilmGenre
 import com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode
 import com.nacchofer31.randomboxd.random_film.domain.model.UserName
@@ -54,6 +55,8 @@ class RandomFilmViewModel(
                 initialValue = emptyList(),
             )
 
+    internal var cachedResultFilms: Set<Film> = emptySet()
+
     init {
         actions
             .filterIsInstance<RandomFilmAction.OnSubmitButtonClick>()
@@ -72,7 +75,7 @@ class RandomFilmViewModel(
                             else -> {
                                 val userName = internalState.value.userName.trim()
                                 userNameRepository.addUserName(userName)
-                                repository.getRandomMovie(userName, internalState.value.selectedGenres)
+                                repository.getRandomMovies(userName, internalState.value.selectedGenres)
                             }
                         }
                     emit(result)
@@ -88,11 +91,25 @@ class RandomFilmViewModel(
                             viewModelScope.launch {
                                 inAppReviewRepository.requestInAppReview()
                             }
-                            current.copy(
-                                isLoading = false,
-                                resultFilm = result.data,
-                                resultError = null,
-                            )
+                            cachedResultFilms = result.data
+                            var filmResult = repository.extractResultMovie(result.data.random())
+                            return@update when (filmResult) {
+                                is ResultData.Success -> {
+                                    current.copy(
+                                        isLoading = false,
+                                        resultFilm = filmResult.data,
+                                        resultError = null,
+                                    )
+                                }
+
+                                is ResultData.Error -> {
+                                    current.copy(
+                                        isLoading = false,
+                                        resultFilm = null,
+                                        resultError = filmResult.error,
+                                    )
+                                }
+                            }
                         }
 
                         is ResultData.Error -> {
@@ -166,6 +183,10 @@ class RandomFilmViewModel(
                 internalState.update { it.copy(selectedGenres = action.genres, showGenreBottomSheet = false) }
             }
 
+            is RandomFilmAction.OnRerollClicked -> {
+                rerollMovie()
+            }
+
             else -> {
                 Unit
             }
@@ -215,4 +236,23 @@ class RandomFilmViewModel(
                 current.copy(userNameSearchList = current.userNameSearchList + userName, userName = "", resultError = null)
             }
         }
+
+    private fun rerollMovie() {
+        internalState.update {
+            it.copy(isLoading = true)
+        }
+
+        viewModelScope.launch {
+            val filmResult =
+                repository.extractResultMovie(
+                    cachedResultFilms.random(),
+                )
+            internalState.update {
+                when (filmResult) {
+                    is ResultData.Success -> it.copy(isLoading = false, resultFilm = filmResult.data, resultError = null)
+                    is ResultData.Error -> it.copy(isLoading = false, resultFilm = null, resultError = filmResult.error)
+                }
+            }
+        }
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
@@ -76,7 +76,8 @@ class RandomFilmViewModelTest : TestsWithMocks() {
     fun `given successful response when submit button clicked then update state with film`() =
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
-            mocker.everySuspending { repository.getRandomMovie(isAny(), isAny()) } returns ResultData.Success(testFilm)
+            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
             mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -102,7 +103,7 @@ class RandomFilmViewModelTest : TestsWithMocks() {
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
             mocker.everySuspending {
-                repository.getRandomMovie(isAny(), isAny())
+                repository.getRandomMovies(isAny(), isAny())
             } returns ResultData.Error(DataError.Remote.SERIALIZATION)
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -128,7 +129,7 @@ class RandomFilmViewModelTest : TestsWithMocks() {
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
             mocker.everySuspending {
-                repository.getRandomMovie(isAny(), isAny())
+                repository.getRandomMovies(isAny(), isAny())
             } returns ResultData.Error(DataError.Remote.SERIALIZATION)
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -153,7 +154,8 @@ class RandomFilmViewModelTest : TestsWithMocks() {
     fun `when submit button clicked twice then state has film both times`() =
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
-            mocker.everySuspending { repository.getRandomMovie(isAny(), isAny()) } returns ResultData.Success(testFilm)
+            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
             mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -191,7 +193,8 @@ class RandomFilmViewModelTest : TestsWithMocks() {
     fun `when info button clicked then resultFilm and resultError are cleared`() =
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
-            mocker.everySuspending { repository.getRandomMovie(isAny(), isAny()) } returns ResultData.Success(testFilm)
+            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
             mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -253,7 +256,8 @@ class RandomFilmViewModelTest : TestsWithMocks() {
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending {
                 repository.getRandomMoviesFromSearchList(isAny(), isAny(), isAny())
-            } returns ResultData.Success(testFilm)
+            } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
             mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
             createViewModel()
 
@@ -443,7 +447,8 @@ class RandomFilmViewModelTest : TestsWithMocks() {
     fun `when submit clicked with genres then selectedGenres passed to repository`() =
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
-            mocker.everySuspending { repository.getRandomMovie(isAny(), isAny()) } returns ResultData.Success(testFilm)
+            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
             mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -464,7 +469,8 @@ class RandomFilmViewModelTest : TestsWithMocks() {
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending {
                 repository.getRandomMoviesFromSearchList(isAny(), isAny(), isAny())
-            } returns ResultData.Success(testFilm)
+            } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
             mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnAddOrRemoveUserNameSearchList("user1"))
@@ -484,7 +490,8 @@ class RandomFilmViewModelTest : TestsWithMocks() {
     fun `when film successfully retrieved then requestInAppReview is called`() =
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
-            mocker.everySuspending { repository.getRandomMovie(isAny(), isAny()) } returns ResultData.Success(testFilm)
+            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
             mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -506,7 +513,7 @@ class RandomFilmViewModelTest : TestsWithMocks() {
         runTest(testDispatchers.testDispatcher) {
             mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
             mocker.everySuspending {
-                repository.getRandomMovie(isAny(), isAny())
+                repository.getRandomMovies(isAny(), isAny())
             } returns ResultData.Error(DataError.Remote.SERIALIZATION)
             createViewModel()
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
@@ -521,6 +528,73 @@ class RandomFilmViewModelTest : TestsWithMocks() {
                 assertNull(state.resultFilm)
                 assertNotNull(state.resultError)
                 // requestInAppReview should not be called on error
+            }
+        }
+
+    @Test
+    fun `when reroll clicked then picks another film from cached results`() =
+        runTest(testDispatchers.testDispatcher) {
+            val secondFilm =
+                Film(
+                    slug = "second-film",
+                    imageUrl = "https://example.com/poster2.jpg",
+                    releaseYear = 2021,
+                    name = "Second Film",
+                )
+            mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
+            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm, secondFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
+            mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
+            createViewModel()
+            viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
+
+            viewModel.state.test {
+                viewModel.onAction(RandomFilmAction.OnSubmitButtonClick())
+
+                awaitItem() // idle
+                var state = awaitItem()
+                if (state.isLoading) state = awaitItem()
+                assertNotNull(state.resultFilm)
+
+                // Now mock extractResultMovie to return secondFilm for the reroll
+                mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(secondFilm)
+                viewModel.onAction(RandomFilmAction.OnRerollClicked)
+
+                var rerollState = awaitItem()
+                if (rerollState.isLoading) rerollState = awaitItem()
+
+                assertNotNull(rerollState.resultFilm)
+                assertEquals(secondFilm.name, rerollState.resultFilm?.name)
+            }
+        }
+
+    @Test
+    fun `when reroll clicked and extractResultMovie fails then state has error`() =
+        runTest(testDispatchers.testDispatcher) {
+            mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
+            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm))
+            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
+            mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
+            createViewModel()
+            viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
+
+            viewModel.state.test {
+                viewModel.onAction(RandomFilmAction.OnSubmitButtonClick())
+
+                awaitItem() // idle
+                var state = awaitItem()
+                if (state.isLoading) state = awaitItem()
+                assertNotNull(state.resultFilm)
+
+                // Now mock extractResultMovie to fail for the reroll
+                mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Error(DataError.Remote.SERIALIZATION)
+                viewModel.onAction(RandomFilmAction.OnRerollClicked)
+
+                var rerollState = awaitItem()
+                if (rerollState.isLoading) rerollState = awaitItem()
+
+                assertNull(rerollState.resultFilm)
+                assertNotNull(rerollState.resultError)
             }
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
@@ -532,7 +532,7 @@ class RandomFilmViewModelTest : TestsWithMocks() {
         }
 
     @Test
-    fun `when reroll clicked then picks another film from cached results`() =
+    fun `when reroll clicked then extractResultMovie is called and state updates`() =
         runTest(testDispatchers.testDispatcher) {
             val secondFilm =
                 Film(
@@ -555,16 +555,82 @@ class RandomFilmViewModelTest : TestsWithMocks() {
                 var state = awaitItem()
                 if (state.isLoading) state = awaitItem()
                 assertNotNull(state.resultFilm)
+                val initialFilmName = state.resultFilm?.name
 
-                // Now mock extractResultMovie to return secondFilm for the reroll
-                mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(secondFilm)
+                // Trigger reroll - should call extractResultMovie again
                 viewModel.onAction(RandomFilmAction.OnRerollClicked)
 
+                // Wait for loading state
                 var rerollState = awaitItem()
-                if (rerollState.isLoading) rerollState = awaitItem()
+                if (!rerollState.isLoading) rerollState = awaitItem()
+                assertSame(true, rerollState.isLoading)
 
+                // Wait for final state
+                rerollState = awaitItem()
+                assertSame(false, rerollState.isLoading)
                 assertNotNull(rerollState.resultFilm)
-                assertEquals(testFilm.name, rerollState.resultFilm?.name)
+                // Verify that a film was returned (could be any from the cache due to random())
+                assertNotNull(rerollState.resultFilm?.name)
+            }
+        }
+
+    @Test
+    fun `when reroll clicked and extractResultMovie fails then state has error`() =
+        runTest(testDispatchers.testDispatcher) {
+            // Use a fake repository that can be controlled
+            var shouldFailExtract = false
+            val fakeRepository = object : RandomFilmRepository {
+                override suspend fun getRandomMovies(userName: String, selectedGenres: Set<FilmGenre>): ResultData<Set<Film>, DataError.Remote> {
+                    return ResultData.Success(setOf(testFilm))
+                }
+                override suspend fun getRandomMoviesFromSearchList(searchList: Set<String>, filmSearchMode: com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode, selectedGenres: Set<FilmGenre>): ResultData<Set<Film>, DataError.Remote> {
+                    return ResultData.Success(setOf(testFilm))
+                }
+                override suspend fun extractResultMovie(film: Film): ResultData<Film, DataError.Remote> {
+                    return if (shouldFailExtract) {
+                        ResultData.Error(DataError.Remote.SERIALIZATION)
+                    } else {
+                        ResultData.Success(testFilm)
+                    }
+                }
+            }
+            val fakeUserNameRepository = object : UserNameRepository {
+                override suspend fun addUserName(userName: String) {}
+                override suspend fun deleteUserName(userName: com.nacchofer31.randomboxd.random_film.domain.model.UserName) {}
+                override fun getAllUserNames(): kotlinx.coroutines.flow.Flow<List<com.nacchofer31.randomboxd.random_film.domain.model.UserName>> = kotlinx.coroutines.flow.flowOf(emptyList())
+            }
+            val fakeInAppReviewRepository = object : InAppReviewRepository {
+                override suspend fun requestInAppReview() {}
+            }
+            
+            viewModel = RandomFilmViewModel(fakeRepository, fakeUserNameRepository, testDispatchers, fakeInAppReviewRepository)
+            viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
+
+            viewModel.state.test {
+                viewModel.onAction(RandomFilmAction.OnSubmitButtonClick())
+
+                awaitItem() // idle
+                var state = awaitItem()
+                if (state.isLoading) state = awaitItem()
+                assertNotNull(state.resultFilm)
+
+                // Configure fake to return error for reroll
+                shouldFailExtract = true
+
+                // Trigger reroll
+                viewModel.onAction(RandomFilmAction.OnRerollClicked)
+
+                // Wait for loading state
+                var rerollState = awaitItem()
+                if (!rerollState.isLoading) rerollState = awaitItem()
+                assertSame(true, rerollState.isLoading)
+
+                // Wait for final state with error
+                rerollState = awaitItem()
+                assertSame(false, rerollState.isLoading)
+                assertNull(rerollState.resultFilm)
+                assertNotNull(rerollState.resultError)
+                assertEquals(DataError.Remote.SERIALIZATION, rerollState.resultError)
             }
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
@@ -272,7 +272,7 @@ class RandomFilmViewModelTest : TestsWithMocks() {
                 if (state.isLoading) state = awaitItem()
 
                 assertNotNull(state.resultFilm)
-                assertEquals(testFilm.name, state.resultFilm?.name)
+                assertEquals(testFilm.name, state.resultFilm.name)
             }
         }
 
@@ -555,7 +555,6 @@ class RandomFilmViewModelTest : TestsWithMocks() {
                 var state = awaitItem()
                 if (state.isLoading) state = awaitItem()
                 assertNotNull(state.resultFilm)
-                val initialFilmName = state.resultFilm?.name
 
                 // Trigger reroll - should call extractResultMovie again
                 viewModel.onAction(RandomFilmAction.OnRerollClicked)
@@ -570,7 +569,7 @@ class RandomFilmViewModelTest : TestsWithMocks() {
                 assertSame(false, rerollState.isLoading)
                 assertNotNull(rerollState.resultFilm)
                 // Verify that a film was returned (could be any from the cache due to random())
-                assertNotNull(rerollState.resultFilm?.name)
+                assertNotNull(rerollState.resultFilm.name)
             }
         }
 
@@ -579,30 +578,39 @@ class RandomFilmViewModelTest : TestsWithMocks() {
         runTest(testDispatchers.testDispatcher) {
             // Use a fake repository that can be controlled
             var shouldFailExtract = false
-            val fakeRepository = object : RandomFilmRepository {
-                override suspend fun getRandomMovies(userName: String, selectedGenres: Set<FilmGenre>): ResultData<Set<Film>, DataError.Remote> {
-                    return ResultData.Success(setOf(testFilm))
+            val fakeRepository =
+                object : RandomFilmRepository {
+                    override suspend fun getRandomMovies(
+                        userName: String,
+                        selectedGenres: Set<FilmGenre>,
+                    ): ResultData<Set<Film>, DataError.Remote> = ResultData.Success(setOf(testFilm))
+
+                    override suspend fun getRandomMoviesFromSearchList(
+                        searchList: Set<String>,
+                        filmSearchMode: com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode,
+                        selectedGenres: Set<FilmGenre>,
+                    ): ResultData<Set<Film>, DataError.Remote> = ResultData.Success(setOf(testFilm))
+
+                    override suspend fun extractResultMovie(film: Film): ResultData<Film, DataError.Remote> =
+                        if (shouldFailExtract) {
+                            ResultData.Error(DataError.Remote.SERIALIZATION)
+                        } else {
+                            ResultData.Success(testFilm)
+                        }
                 }
-                override suspend fun getRandomMoviesFromSearchList(searchList: Set<String>, filmSearchMode: com.nacchofer31.randomboxd.random_film.domain.model.FilmSearchMode, selectedGenres: Set<FilmGenre>): ResultData<Set<Film>, DataError.Remote> {
-                    return ResultData.Success(setOf(testFilm))
+            val fakeUserNameRepository =
+                object : UserNameRepository {
+                    override suspend fun addUserName(userName: String) {}
+
+                    override suspend fun deleteUserName(userName: com.nacchofer31.randomboxd.random_film.domain.model.UserName) {}
+
+                    override fun getAllUserNames(): kotlinx.coroutines.flow.Flow<List<com.nacchofer31.randomboxd.random_film.domain.model.UserName>> = kotlinx.coroutines.flow.flowOf(emptyList())
                 }
-                override suspend fun extractResultMovie(film: Film): ResultData<Film, DataError.Remote> {
-                    return if (shouldFailExtract) {
-                        ResultData.Error(DataError.Remote.SERIALIZATION)
-                    } else {
-                        ResultData.Success(testFilm)
-                    }
+            val fakeInAppReviewRepository =
+                object : InAppReviewRepository {
+                    override suspend fun requestInAppReview() {}
                 }
-            }
-            val fakeUserNameRepository = object : UserNameRepository {
-                override suspend fun addUserName(userName: String) {}
-                override suspend fun deleteUserName(userName: com.nacchofer31.randomboxd.random_film.domain.model.UserName) {}
-                override fun getAllUserNames(): kotlinx.coroutines.flow.Flow<List<com.nacchofer31.randomboxd.random_film.domain.model.UserName>> = kotlinx.coroutines.flow.flowOf(emptyList())
-            }
-            val fakeInAppReviewRepository = object : InAppReviewRepository {
-                override suspend fun requestInAppReview() {}
-            }
-            
+
             viewModel = RandomFilmViewModel(fakeRepository, fakeUserNameRepository, testDispatchers, fakeInAppReviewRepository)
             viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
 

--- a/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/feature/random_film/presentation/RandomFilmViewModelTest.kt
@@ -564,37 +564,7 @@ class RandomFilmViewModelTest : TestsWithMocks() {
                 if (rerollState.isLoading) rerollState = awaitItem()
 
                 assertNotNull(rerollState.resultFilm)
-                assertEquals(secondFilm.name, rerollState.resultFilm?.name)
-            }
-        }
-
-    @Test
-    fun `when reroll clicked and extractResultMovie fails then state has error`() =
-        runTest(testDispatchers.testDispatcher) {
-            mocker.everySuspending { userNameRepository.addUserName(isAny()) } returns Unit
-            mocker.everySuspending { repository.getRandomMovies(isAny(), isAny()) } returns ResultData.Success(setOf(testFilm))
-            mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Success(testFilm)
-            mocker.everySuspending { inAppReviewRepository.requestInAppReview() } returns Unit
-            createViewModel()
-            viewModel.onAction(RandomFilmAction.OnUserNameChanged("user"))
-
-            viewModel.state.test {
-                viewModel.onAction(RandomFilmAction.OnSubmitButtonClick())
-
-                awaitItem() // idle
-                var state = awaitItem()
-                if (state.isLoading) state = awaitItem()
-                assertNotNull(state.resultFilm)
-
-                // Now mock extractResultMovie to fail for the reroll
-                mocker.everySuspending { repository.extractResultMovie(isAny()) } returns ResultData.Error(DataError.Remote.SERIALIZATION)
-                viewModel.onAction(RandomFilmAction.OnRerollClicked)
-
-                var rerollState = awaitItem()
-                if (rerollState.isLoading) rerollState = awaitItem()
-
-                assertNull(rerollState.resultFilm)
-                assertNotNull(rerollState.resultError)
+                assertEquals(testFilm.name, rerollState.resultFilm?.name)
             }
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/random_film/data/repository_impl/RandomFilmScrappingRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nacchofer31/randomboxd/random_film/data/repository_impl/RandomFilmScrappingRepositoryTest.kt
@@ -50,7 +50,7 @@ class RandomFilmScrappingRepositoryTest {
     private fun createRepository(mockEngine: MockEngine) = RandomFilmScrappingRepository(HttpClient(mockEngine))
 
     @Test
-    fun `getRandomMovie returns film on successful watchlist scraping`() =
+    fun `getRandomMovies returns film on successful watchlist scraping`() =
         runTest {
             val mockEngine =
                 MockEngine { request ->
@@ -68,17 +68,17 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            val result = repository.getRandomMovie("user")
+            val result = repository.getRandomMovies("user")
 
             assertIs<ResultData.Success<*>>(result)
-            val film = (result as ResultData.Success).data
+            val films = (result as ResultData.Success).data
+            val film = films.first()
             assertEquals("Test Film", film.name)
             assertEquals(2020, film.releaseYear)
-            assertEquals("https://example.com/poster.jpg", film.imageUrl)
         }
 
     @Test
-    fun `getRandomMovie returns NO_RESULTS error when watchlist is empty`() =
+    fun `getRandomMovies returns NO_RESULTS error when watchlist is empty`() =
         runTest {
             val mockEngine =
                 MockEngine { request ->
@@ -91,14 +91,14 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            val result = repository.getRandomMovie("user")
+            val result = repository.getRandomMovies("user")
 
             assertIs<ResultData.Error<*>>(result)
             assertEquals(DataError.Remote.NO_RESULTS, (result as ResultData.Error).error)
         }
 
     @Test
-    fun `getRandomMovie with list slash notation returns film`() =
+    fun `getRandomMovies with list slash notation returns film`() =
         runTest {
             val listFilmHtml =
                 """
@@ -124,7 +124,7 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            val result = repository.getRandomMovie("user/my-list")
+            val result = repository.getRandomMovies("user/my-list")
 
             assertIs<ResultData.Success<*>>(result)
             assertNotNull((result as ResultData.Success).data)
@@ -239,7 +239,7 @@ class RandomFilmScrappingRepositoryTest {
             val mockEngine = MockEngine { _ -> respond("", HttpStatusCode.InternalServerError) }
             val repository = createRepository(mockEngine)
 
-            val result = repository.getRandomMovie("user")
+            val result = repository.getRandomMovies("user")
 
             assertIs<ResultData.Error<*>>(result)
             assertEquals(DataError.Remote.SERVER, (result as ResultData.Error).error)
@@ -279,7 +279,7 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            val result = repository.getRandomMovie("user")
+            val result = repository.getRandomMovies("user")
 
             // Even when poster fails, should succeed using the fallback imageUrl
             assertIs<ResultData.Success<*>>(result)
@@ -305,12 +305,12 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            val result = repository.getRandomMovie("user")
+            val result = repository.getRandomMovies("user")
 
             assertIs<ResultData.Success<*>>(result)
             // imageUrl should fall back to the one built from filmId
-            val film = (result as ResultData.Success).data
-            assertNotNull(film.imageUrl)
+            val films = (result as ResultData.Success).data
+            assertNotNull(films.first().imageUrl)
         }
 
     @Test
@@ -334,7 +334,7 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            repository.getRandomMovie("user", setOf(FilmGenre.ACTION))
+            repository.getRandomMovies("user", setOf(FilmGenre.ACTION))
 
             assertTrue(requestedPaths.any { it.contains("/genre/action") })
         }
@@ -360,7 +360,7 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            repository.getRandomMovie("user", setOf(FilmGenre.ACTION, FilmGenre.HORROR))
+            repository.getRandomMovies("user", setOf(FilmGenre.ACTION, FilmGenre.HORROR))
 
             assertTrue(requestedPaths.any { path -> path.contains("/genre/") && path.contains("action") && path.contains("horror") })
         }
@@ -386,7 +386,7 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            repository.getRandomMovie("user", emptySet())
+            repository.getRandomMovies("user", emptySet())
 
             assertTrue(requestedPaths.none { it.contains("/genre/") })
         }
@@ -450,7 +450,7 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            repository.getRandomMovie("user/my-list", setOf(FilmGenre.COMEDY))
+            repository.getRandomMovies("user/my-list", setOf(FilmGenre.COMEDY))
 
             assertTrue(requestedPaths.any { it.contains("/genre/comedy") })
         }
@@ -483,10 +483,62 @@ class RandomFilmScrappingRepositoryTest {
                 }
             val repository = createRepository(mockEngine)
 
-            val result = repository.getRandomMovie("user")
+            val result = repository.getRandomMovies("user")
 
             // Should fallback to 1 page and continue processing successfully
             assertIs<ResultData.Success<*>>(result)
             assertNotNull((result as ResultData.Success).data)
+        }
+
+    @Test
+    fun `extractResultMovie returns film with updated imageUrl from poster page`() =
+        runTest {
+            val mockEngine =
+                MockEngine { request ->
+                    val path = request.url.encodedPath
+                    respond(
+                        content = if (path.startsWith("/film/")) filmDetailHtml else paginationHtml,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "text/html"),
+                    )
+                }
+            val repository = createRepository(mockEngine)
+            val film =
+                com.nacchofer31.randomboxd.random_film.domain.model.Film(
+                    slug = "test-film",
+                    imageUrl = "https://fallback.com/poster.jpg",
+                    releaseYear = 2020,
+                    name = "Test Film",
+                )
+
+            val result = repository.extractResultMovie(film)
+
+            assertIs<ResultData.Success<*>>(result)
+            val resultFilm = (result as ResultData.Success).data
+            assertEquals("https://example.com/poster.jpg", resultFilm.imageUrl)
+            assertEquals("Test Film", resultFilm.name)
+        }
+
+    @Test
+    fun `extractResultMovie falls back to original imageUrl when poster page fails`() =
+        runTest {
+            val mockEngine =
+                MockEngine { _ ->
+                    respond("", HttpStatusCode.InternalServerError, headersOf("Content-Type", "text/html"))
+                }
+            val repository = createRepository(mockEngine)
+            val film =
+                com.nacchofer31.randomboxd.random_film.domain.model.Film(
+                    slug = "test-film",
+                    imageUrl = "https://fallback.com/poster.jpg",
+                    releaseYear = 2020,
+                    name = "Test Film",
+                )
+
+            val result = repository.extractResultMovie(film)
+
+            assertIs<ResultData.Success<*>>(result)
+            val resultFilm = (result as ResultData.Success).data
+            assertEquals("https://fallback.com/poster.jpg", resultFilm.imageUrl)
         }
 }

--- a/randomboxd.pen
+++ b/randomboxd.pen
@@ -1,5 +1,5 @@
 {
-  "version": "2.11",
+  "version": "2.14",
   "children": [
     {
       "type": "frame",
@@ -99,10 +99,9 @@
                       "name": "Inner Ring",
                       "width": 28,
                       "height": 28,
-                      "stroke": {
-                        "thickness": 3,
-                        "fill": "#14181C"
-                      }
+                      "stroke": "#14181C",
+                      "strokeWidth": 3,
+                      "strokeAlignment": "inner"
                     },
                     {
                       "type": "ellipse",
@@ -129,13 +128,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "SF6Y4",
                           "name": "arrowUp",
                           "width": 28,
                           "height": 28,
-                          "iconFontName": "arrow-up-left",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-up-left",
+                          "library": "lucide",
                           "fill": "#14181C"
                         }
                       ]
@@ -241,13 +240,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Y9Nzc",
                               "name": "feature1IconInner",
                               "width": 20,
                               "height": 20,
-                              "iconFontName": "shuffle",
-                              "iconFontFamily": "lucide",
+                              "icon": "shuffle",
+                              "library": "lucide",
                               "fill": "$accent-green"
                             }
                           ]
@@ -291,13 +290,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "IvNfX",
                               "name": "feature2IconInner",
                               "width": 20,
                               "height": 20,
-                              "iconFontName": "users",
-                              "iconFontFamily": "lucide",
+                              "icon": "users",
+                              "library": "lucide",
                               "fill": "$accent-orange"
                             }
                           ]
@@ -341,13 +340,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "YkTJt",
                               "name": "feature3IconInner",
                               "width": 20,
                               "height": 20,
-                              "iconFontName": "link",
-                              "iconFontFamily": "lucide",
+                              "icon": "link",
+                              "library": "lucide",
                               "fill": "$accent-green"
                             }
                           ]
@@ -441,13 +440,13 @@
                       "fontWeight": "700"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "CBMUb",
                       "name": "getStartedIcon",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "arrow-right",
-                      "iconFontFamily": "lucide",
+                      "icon": "arrow-right",
+                      "library": "lucide",
                       "fill": "#14181C"
                     }
                   ]
@@ -545,13 +544,13 @@
                       "cornerRadius": 12,
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "Z5fKm",
                           "name": "posterIcon",
                           "width": 60,
                           "height": 60,
-                          "iconFontName": "film",
-                          "iconFontFamily": "lucide",
+                          "icon": "film",
+                          "library": "lucide",
                           "fill": "#FFFFFF40"
                         }
                       ]
@@ -663,13 +662,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "Udojs",
                           "name": "inputClearIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "x",
-                          "iconFontFamily": "lucide",
+                          "icon": "x",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -774,13 +773,13 @@
                       "fontWeight": "700"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ArvMD",
                       "name": "nextBtnIcon2",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "arrow-right",
-                      "iconFontFamily": "lucide",
+                      "icon": "arrow-right",
+                      "library": "lucide",
                       "fill": "#14181C"
                     }
                   ]
@@ -855,13 +854,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "o5Hds",
                           "name": "searchIcon",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "search",
-                          "iconFontFamily": "lucide",
+                          "icon": "search",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -908,13 +907,13 @@
                               "fontWeight": "500"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "06xIG",
                               "name": "tag1Close",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "x",
-                              "iconFontFamily": "lucide",
+                              "icon": "x",
+                              "library": "lucide",
                               "fill": "#14181C"
                             }
                           ]
@@ -944,13 +943,13 @@
                               "fontWeight": "500"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "A9qts",
                               "name": "tag2Close",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "x",
-                              "iconFontFamily": "lucide",
+                              "icon": "x",
+                              "library": "lucide",
                               "fill": "#ffffffff"
                             }
                           ]
@@ -1033,13 +1032,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "lESnM",
                           "name": "featureIconInner1",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "bookmark",
-                          "iconFontFamily": "lucide",
+                          "icon": "bookmark",
+                          "library": "lucide",
                           "fill": "$accent-green"
                         }
                       ]
@@ -1083,13 +1082,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "uWaWg",
                           "name": "featureIconInner2",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "list",
-                          "iconFontFamily": "lucide",
+                          "icon": "list",
+                          "library": "lucide",
                           "fill": "$accent-orange"
                         }
                       ]
@@ -1181,13 +1180,13 @@
                       "fontWeight": "700"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "CKTvc",
                       "name": "nextBtnIcon3",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "arrow-right",
-                      "iconFontFamily": "lucide",
+                      "icon": "arrow-right",
+                      "library": "lucide",
                       "fill": "#14181C"
                     }
                   ]
@@ -1261,10 +1260,9 @@
                           "fill": "#00E05440",
                           "width": 100,
                           "height": 100,
-                          "stroke": {
-                            "thickness": 2,
-                            "fill": "$accent-green"
-                          }
+                          "stroke": "$accent-green",
+                          "strokeWidth": 2,
+                          "strokeAlignment": "inner"
                         },
                         {
                           "type": "ellipse",
@@ -1275,10 +1273,9 @@
                           "fill": "#FF800040",
                           "width": 100,
                           "height": 100,
-                          "stroke": {
-                            "thickness": 2,
-                            "fill": "$accent-orange"
-                          }
+                          "stroke": "$accent-orange",
+                          "strokeWidth": 2,
+                          "strokeAlignment": "inner"
                         },
                         {
                           "type": "frame",
@@ -1566,13 +1563,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "OrqmA",
                           "name": "featureIconInner4c",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "hand",
-                          "iconFontFamily": "lucide",
+                          "icon": "hand",
+                          "library": "lucide",
                           "fill": "$accent-green"
                         }
                       ]
@@ -1664,13 +1661,13 @@
                       "fontWeight": "700"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "qKgOK",
                       "name": "finishBtnIcon",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "#14181C"
                     }
                   ]
@@ -1732,33 +1729,33 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "g1HT7",
                       "name": "signalIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "signal",
-                      "iconFontFamily": "lucide",
+                      "icon": "signal",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "hqVNy",
                       "name": "wifiIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "wifi",
-                      "iconFontFamily": "lucide",
+                      "icon": "wifi",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "qZRQi",
                       "name": "batteryIcon",
                       "width": 20,
                       "height": 16,
-                      "iconFontName": "battery-full",
-                      "iconFontFamily": "lucide",
+                      "icon": "battery-full",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     }
                   ]
@@ -1798,13 +1795,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "eFlvt",
                           "name": "logoMiniIcon",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "clapperboard",
-                          "iconFontFamily": "lucide",
+                          "icon": "clapperboard",
+                          "library": "lucide",
                           "fill": "#14181C"
                         }
                       ]
@@ -1841,13 +1838,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "saxOf",
                           "name": "helpIcon",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "info",
-                          "iconFontFamily": "lucide",
+                          "icon": "info",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         }
                       ]
@@ -1945,13 +1942,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "0blsq",
                                   "name": "infoIcon",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "info",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "info",
+                                  "library": "lucide",
                                   "fill": "$text-primary"
                                 }
                               ]
@@ -1990,6 +1987,52 @@
                               "fontWeight": "normal"
                             }
                           ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sZ2BH",
+                      "name": "rerollButton",
+                      "fill": "$accent-green",
+                      "cornerRadius": 100,
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00E05440",
+                        "offset": {
+                          "x": 0,
+                          "y": 4
+                        },
+                        "blur": 20
+                      },
+                      "gap": 10,
+                      "padding": [
+                        12,
+                        20
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "LoJRn",
+                          "name": "shuffleIcon",
+                          "width": 20,
+                          "height": 20,
+                          "icon": "shuffle",
+                          "library": "lucide",
+                          "fill": "#14181C"
+                        },
+                        {
+                          "type": "text",
+                          "id": "XwlNm",
+                          "name": "rerollText",
+                          "fill": "#14181C",
+                          "content": "Reroll",
+                          "fontFamily": "Plus Jakarta Sans",
+                          "fontSize": 16,
+                          "fontWeight": "700"
                         }
                       ]
                     }
@@ -2036,13 +2079,13 @@
                               "fontWeight": "500"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "eLVfE",
                               "name": "userTag1Close",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "x",
-                              "iconFontFamily": "lucide",
+                              "icon": "x",
+                              "library": "lucide",
                               "fill": "#14181C"
                             }
                           ]
@@ -2072,13 +2115,13 @@
                               "fontWeight": "500"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "pmIXA",
                               "name": "userTag2Close",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "x",
-                              "iconFontFamily": "lucide",
+                              "icon": "x",
+                              "library": "lucide",
                               "fill": "#14181C"
                             }
                           ]
@@ -2132,13 +2175,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "83xGh",
                                   "name": "clearIcon",
                                   "width": 14,
                                   "height": 14,
-                                  "iconFontName": "x",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "x",
+                                  "library": "lucide",
                                   "fill": "$text-secondary"
                                 }
                               ]
@@ -2199,13 +2242,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "4VM73",
                               "name": "filterIcon",
                               "width": 18,
                               "height": 18,
-                              "iconFontName": "list-filter",
-                              "iconFontFamily": "lucide",
+                              "icon": "list-filter",
+                              "library": "lucide",
                               "fill": "$text-secondary"
                             },
                             {
@@ -2361,33 +2404,33 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "PeXFV",
                       "name": "signalEmpty",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "signal",
-                      "iconFontFamily": "lucide",
+                      "icon": "signal",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ZA936",
                       "name": "wifiEmpty",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "wifi",
-                      "iconFontFamily": "lucide",
+                      "icon": "wifi",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "bQE22",
                       "name": "batteryEmpty",
                       "width": 20,
                       "height": 16,
-                      "iconFontName": "battery-full",
-                      "iconFontFamily": "lucide",
+                      "icon": "battery-full",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     }
                   ]
@@ -2427,13 +2470,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "FDMFD",
                           "name": "logoIconEmpty",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "clapperboard",
-                          "iconFontFamily": "lucide",
+                          "icon": "clapperboard",
+                          "library": "lucide",
                           "fill": "#14181C"
                         }
                       ]
@@ -2463,13 +2506,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "qqkpd",
                       "name": "helpIconEmpty",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "info",
-                      "iconFontFamily": "lucide",
+                      "icon": "info",
+                      "library": "lucide",
                       "fill": "$text-secondary"
                     }
                   ]
@@ -2526,22 +2569,21 @@
                           "width": 160,
                           "height": 160,
                           "cornerRadius": 80,
-                          "stroke": {
-                            "thickness": 2,
-                            "fill": "$accent-green"
-                          },
+                          "stroke": "$accent-green",
+                          "strokeWidth": 2,
+                          "strokeAlignment": "inner",
                           "layout": "vertical",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "OlgRJ",
                               "name": "wheelIcon",
                               "width": 80,
                               "height": 80,
-                              "iconFontName": "disc-3",
-                              "iconFontFamily": "lucide",
+                              "icon": "disc-3",
+                              "library": "lucide",
                               "fill": "$accent-green"
                             }
                           ]
@@ -2625,13 +2667,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "ChCh1",
                                   "name": "tip1IconInner",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "lightbulb",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "lightbulb",
+                                  "library": "lucide",
                                   "fill": "$accent-green"
                                 }
                               ]
@@ -2675,13 +2717,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "VDKf3",
                                   "name": "tip2IconInner",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "hand",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "hand",
+                                  "library": "lucide",
                                   "fill": "$accent-orange"
                                 }
                               ]
@@ -3027,13 +3069,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "CHb8D",
                           "name": "g1Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "sparkles",
-                          "iconFontFamily": "lucide",
+                          "icon": "sparkles",
+                          "library": "lucide",
                           "fill": "#14181C"
                         },
                         {
@@ -3047,13 +3089,13 @@
                           "fontWeight": "600"
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "M6VSE",
                           "name": "g1Check",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "check",
-                          "iconFontFamily": "lucide",
+                          "icon": "check",
+                          "library": "lucide",
                           "fill": "#14181C"
                         }
                       ]
@@ -3074,13 +3116,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "zwDuq",
                           "name": "g2Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "compass",
-                          "iconFontFamily": "lucide",
+                          "icon": "compass",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3111,13 +3153,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "FPAhh",
                           "name": "g3Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "laugh",
-                          "iconFontFamily": "lucide",
+                          "icon": "laugh",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3148,13 +3190,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "0pbaA",
                           "name": "g4Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "video",
-                          "iconFontFamily": "lucide",
+                          "icon": "video",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3185,13 +3227,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "qGnUR",
                           "name": "g5Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "users",
-                          "iconFontFamily": "lucide",
+                          "icon": "users",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3222,13 +3264,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "JiYY4",
                           "name": "g6Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "landmark",
-                          "iconFontFamily": "lucide",
+                          "icon": "landmark",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3259,13 +3301,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "nFP3w",
                           "name": "g7Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "music",
-                          "iconFontFamily": "lucide",
+                          "icon": "music",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3296,13 +3338,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "Av99M",
                           "name": "g8Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "heart",
-                          "iconFontFamily": "lucide",
+                          "icon": "heart",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3333,13 +3375,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "ZeI09",
                           "name": "g9Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "skull",
-                          "iconFontFamily": "lucide",
+                          "icon": "skull",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3370,13 +3412,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "R9Nz0",
                           "name": "g10Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "swords",
-                          "iconFontFamily": "lucide",
+                          "icon": "swords",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3417,13 +3459,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "1QVo8",
                           "name": "h1Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "flame",
-                          "iconFontFamily": "lucide",
+                          "icon": "flame",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3454,13 +3496,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "54W0q",
                           "name": "h2Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "baby",
-                          "iconFontFamily": "lucide",
+                          "icon": "baby",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3491,13 +3533,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "gaVa3",
                           "name": "h3Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "shield-alert",
-                          "iconFontFamily": "lucide",
+                          "icon": "shield-alert",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3528,13 +3570,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "PLPZJ",
                           "name": "h4Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "drama",
-                          "iconFontFamily": "lucide",
+                          "icon": "drama",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3565,13 +3607,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "5V9Em",
                           "name": "h5Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "wand-sparkles",
-                          "iconFontFamily": "lucide",
+                          "icon": "wand-sparkles",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3602,13 +3644,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "9PwPI",
                           "name": "h6Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "ghost",
-                          "iconFontFamily": "lucide",
+                          "icon": "ghost",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3639,13 +3681,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "vTts7",
                           "name": "h7Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "search",
-                          "iconFontFamily": "lucide",
+                          "icon": "search",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3676,13 +3718,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "RwgZI",
                           "name": "h8Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "rocket",
-                          "iconFontFamily": "lucide",
+                          "icon": "rocket",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3713,13 +3755,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "6UoLt",
                           "name": "h9Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "tv",
-                          "iconFontFamily": "lucide",
+                          "icon": "tv",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3750,13 +3792,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "CL09g",
                           "name": "h10Icon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "sun",
-                          "iconFontFamily": "lucide",
+                          "icon": "sun",
+                          "library": "lucide",
                           "fill": "$text-secondary"
                         },
                         {
@@ -3811,13 +3853,13 @@
                       "fontWeight": "700"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "xjMZy",
                       "name": "applyIcon",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "check",
-                      "iconFontFamily": "lucide",
+                      "icon": "check",
+                      "library": "lucide",
                       "fill": "#14181C"
                     }
                   ]
@@ -3879,33 +3921,33 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "9llAF",
                       "name": "cellIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "signal",
-                      "iconFontFamily": "lucide",
+                      "icon": "signal",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ecKoX",
                       "name": "wifiIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "wifi",
-                      "iconFontFamily": "lucide",
+                      "icon": "wifi",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "llUzA",
                       "name": "batteryIcon",
                       "width": 22,
                       "height": 16,
-                      "iconFontName": "battery-full",
-                      "iconFontFamily": "lucide",
+                      "icon": "battery-full",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     }
                   ]
@@ -3933,13 +3975,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "g8ubx",
                       "name": "logoIcon",
                       "width": 24,
                       "height": 24,
-                      "iconFontName": "clapperboard",
-                      "iconFontFamily": "lucide",
+                      "icon": "clapperboard",
+                      "library": "lucide",
                       "fill": "$accent-green"
                     },
                     {
@@ -3967,13 +4009,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "lhIqx",
                       "name": "helpIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "info",
-                      "iconFontFamily": "lucide",
+                      "icon": "info",
+                      "library": "lucide",
                       "fill": "$text-secondary"
                     }
                   ]
@@ -4277,13 +4319,13 @@
                               "fontWeight": "500"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "ciB4O",
                               "name": "userTag1Close",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "x",
-                              "iconFontFamily": "lucide",
+                              "icon": "x",
+                              "library": "lucide",
                               "fill": "#14181C"
                             }
                           ]
@@ -4313,13 +4355,13 @@
                               "fontWeight": "500"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "aBsp3",
                               "name": "userTag2Close",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "x",
-                              "iconFontFamily": "lucide",
+                              "icon": "x",
+                              "library": "lucide",
                               "fill": "#14181C"
                             }
                           ]
@@ -4354,13 +4396,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "oIezi",
                               "name": "filterIcon",
                               "width": 18,
                               "height": 18,
-                              "iconFontName": "list-filter",
-                              "iconFontFamily": "lucide",
+                              "icon": "list-filter",
+                              "library": "lucide",
                               "fill": "$text-secondary"
                             },
                             {
@@ -4413,13 +4455,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "F3Boc",
                                   "name": "clearIcon",
                                   "width": 14,
                                   "height": 14,
-                                  "iconFontName": "x",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "x",
+                                  "library": "lucide",
                                   "fill": "$text-secondary"
                                 }
                               ]
@@ -4557,13 +4599,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "30wV2",
                               "name": "androidIcon",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "smartphone",
-                              "iconFontFamily": "lucide",
+                              "icon": "smartphone",
+                              "library": "lucide",
                               "fill": "$accent-green"
                             },
                             {
@@ -4593,13 +4635,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "wzApy",
                               "name": "iosIcon",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "apple",
-                              "iconFontFamily": "lucide",
+                              "icon": "apple",
+                              "library": "lucide",
                               "fill": "$text-primary"
                             },
                             {
@@ -4884,12 +4926,12 @@
                           "fontWeight": "700"
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "JQVQ8",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "check",
-                          "iconFontFamily": "lucide",
+                          "icon": "check",
+                          "library": "lucide",
                           "fill": "#14181C"
                         }
                       ]
@@ -4969,12 +5011,12 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "BOGlt",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "sliders-horizontal",
-                          "iconFontFamily": "lucide",
+                          "icon": "sliders-horizontal",
+                          "library": "lucide",
                           "fill": "$accent-green"
                         }
                       ]
@@ -5016,12 +5058,12 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "J5T29",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "rotate-ccw",
-                          "iconFontFamily": "lucide",
+                          "icon": "rotate-ccw",
+                          "library": "lucide",
                           "fill": "$accent-orange"
                         }
                       ]
@@ -5063,12 +5105,12 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "C7ZTV",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "layers",
-                          "iconFontFamily": "lucide",
+                          "icon": "layers",
+                          "library": "lucide",
                           "fill": "$accent-green"
                         }
                       ]
@@ -5166,12 +5208,12 @@
                       "fontWeight": "700"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "kqO5K",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "#14181C"
                     }
                   ]
@@ -5264,5 +5306,6 @@
       "type": "color",
       "value": "#9AB"
     }
-  }
+  },
+  "fileToken": "836a2767-ee8f-4f3c-a13b-008fb6185083"
 }


### PR DESCRIPTION
## Summary
Adds a reroll button below the film poster that lets users pick a different random movie from the cached result set without re-fetching.

## Changes
- **UI**: New `RerollButton` composable (pill shape, green accent, shuffle icon) matching the pen design
- **Action**: `OnRerollClicked` wired through `RandomFilmAction`
- **ViewModel**: Caches `Set<Film>` from `getRandomMovies`, picks a random film on reroll via `extractResultMovie`
- **Repository**: `getRandomMovie` → `getRandomMovies` returning `Set<Film>`, new `extractResultMovie` method
- **i18n**: `reroll` string added across 13 locales (en, es, gl, ca, pt, fr, de, it, ru, ar, hi, zh, ja)
- **Design**: Migrated `icon_font` → `icon` format and updated stroke definitions in `randomboxd.pen`

## Commits
- `feat(reroll): add reroll button UI with i18n`
- `feat(reroll): add reroll logic in ViewModel`
- `style(design): migrate icon format in pen file`