### PR TITLE
chore(release): bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.4.0
+- Added `Reroll` feature.
+- Added `Number of results` feature.
+
 ## 1.3.0
 - Added `InAppReview` feature.
 - Fixed not localized texts.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -132,8 +132,8 @@ android {
 
     defaultConfig {
         applicationId = "com.nacchofer31.randomboxd"
-        versionName = "1.3.0"
-        versionCode = 18
+        versionName = "1.4.0"
+        versionCode = 19
         minSdk =
             libs.versions.android.minSdk
                 .get()


### PR DESCRIPTION
Release 1.4.0 — Reroll & Number of results

## Changes
- Added Reroll feature
- Added Number of results feature
- Bump versionName to 1.4.0 and versionCode to 19