### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.4.1
+- Prevented film repetition on reroll.
+- Hide `Reroll button` for one results.
+
 ## 1.4.0
 - Added `Reroll` feature.
 - Added `Number of results` feature.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -132,8 +132,8 @@ android {
 
     defaultConfig {
         applicationId = "com.nacchofer31.randomboxd"
-        versionName = "1.4.0"
-        versionCode = 19
+        versionName = "1.4.1"
+        versionCode = 20
         minSdk =
             libs.versions.android.minSdk
                 .get()


### PR DESCRIPTION
### What's Changed
- Prevented film repetition on reroll
- Hide reroll button when only one result is selected

### Details
- Version: `1.4.1` (versionCode `20`)
- Branch: `release/1.4.1`