### PR TITLE
Enable R8 minification for release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ freeline_project_description.json
 
 # ATL (AI tooling local config)
 .atl/
+
+# CodeGraph index
+.codegraph/

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -172,8 +172,13 @@ android {
             enableAndroidTestCoverage = true
         }
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -1,0 +1,12 @@
+# R8 rules for RandomBoxd (composeApp)
+#
+# The default proguard-android-optimize.txt handles Android components,
+# Parcelable, enums and kotlinx-coroutines via bundled consumer rules.
+# Room 2.7.2, kotlinx-serialization 1.9.0 and kotlin-reflect ship their own
+# consumer rules. Koin 4.x resolves definitions by direct class reference
+# (::singleOf/viewModelOf/koinViewModel<T>()), which R8 retains automatically,
+# so no blanket rules are needed for it.
+#
+# Compose Multiplatform resources are accessed statically (Res.string.xxx) and
+# resolved by asset path at runtime, so R8 retains the referenced members.
+

--- a/composeApp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ar/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">جرب: اسم المستخدم أو اسم المستخدم/اسم القائمة</string>
     <string name="tip_hold_submit">اضغط مطولاً على إرسال أو الوسوم لوضع متعدد المستخدمين</string>
     <string name="tip_genre_filter">استخدم زر النوع لتصفية النتائج حسب النوع</string>
+    <string name="tip_history">يمكنك الآن مشاهدة سجل اختياراتك بالضغط على زر السجل</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">لا تواجه صعوبة في اختيار الفيلم مرة أخرى</string>
     <string name="onboarding_welcome_description">احصل على اقتراحات أفلام عشوائية من قوائم المراقبة والقوائم المخصصة على Letterboxd. مثالي لأمسيات الأفلام!</string>

--- a/composeApp/src/commonMain/composeResources/values-ca/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ca/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Prova: usuari o usuari/nom-llista</string>
     <string name="tip_hold_submit">Mantén premut Envia o les etiquetes per al mode multiusuari</string>
     <string name="tip_genre_filter">Usa el botó Gènere per filtrar resultats per gènere</string>
+    <string name="tip_history">Ara pots veure el teu historial de seleccions prement el botó Historial</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">No tornis a tenir problemes per triar pel·lícula</string>
     <string name="onboarding_welcome_description">Obtén suggeriments de pel·lícules aleatòries de les teves llistes de seguiment i llistes personalitzades de Letterboxd. Perfecte per a nits de cinema!</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Versuche: Benutzername oder Benutzername/Listenname</string>
     <string name="tip_hold_submit">Gedrückt halten auf „Senden" oder Tags für den Mehrbenutzermodus</string>
     <string name="tip_genre_filter">Nutze den Genre-Button, um Ergebnisse nach Genre zu filtern</string>
+    <string name="tip_history">Jetzt kannst du deine Auswahlhistorie ansehen, indem du auf den Verlauf-Button drückst</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">Nie wieder Schwierigkeiten bei der Filmauswahl</string>
     <string name="onboarding_welcome_description">Erhalte zufällige Filmvorschläge aus deinen Letterboxd-Watchlists und benutzerdefinierten Listen. Perfekt für Filmabende!</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Prueba: usuario o usuario/nombre-lista</string>
     <string name="tip_hold_submit">Mantén pulsado Buscar o etiquetas para modo multiusuario</string>
     <string name="tip_genre_filter">Usa el botón Género para filtrar los resultados por género</string>
+    <string name="tip_history">Ahora puedes ver tu historial de selecciones pulsando el botón Historial</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">No vuelvas a tener problemas para elegir película</string>
     <string name="onboarding_welcome_description">Obtén sugerencias de películas aleatorias de tus listas de seguimiento y listas personalizadas de Letterboxd. ¡Perfecto para noches de cine!</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Essayez : utilisateur ou utilisateur/nom-liste</string>
     <string name="tip_hold_submit">Appuyez longuement sur Envoyer ou sur les tags pour le mode multi-utilisateur</string>
     <string name="tip_genre_filter">Utilisez le bouton Genre pour filtrer les résultats par genre</string>
+    <string name="tip_history">Vous pouvez désormais consulter votre historique de sélections en appuyant sur le bouton Historique</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">Ne galérez plus jamais pour choisir un film</string>
     <string name="onboarding_welcome_description">Obtenez des suggestions de films aléatoires depuis vos listes de suivi et listes personnalisées Letterboxd. Parfait pour les soirées cinéma !</string>

--- a/composeApp/src/commonMain/composeResources/values-gl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-gl/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Proba: usuario ou usuario/nome-lista</string>
     <string name="tip_hold_submit">Mantén premido Enviar ou as etiquetas para o modo multiusuario</string>
     <string name="tip_genre_filter">Usa o botón Xénero para filtrar os resultados por xénero</string>
+    <string name="tip_history">Agora podes ver o teu historial de seleccións premendo no botón Historial</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">Non volvas ter problemas para escoller película</string>
     <string name="onboarding_welcome_description">Obtén suxestións de películas aleatorias das túas listas de seguimento e listas personalizadas de Letterboxd. Perfecto para noites de cine!</string>

--- a/composeApp/src/commonMain/composeResources/values-hi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-hi/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">प्रयास करें: उपयोगकर्ता नाम या उपयोगकर्ता नाम/सूची-नाम</string>
     <string name="tip_hold_submit">बहु-उपयोगकर्ता मोड के लिए जमा करें या टैग को लंबे समय तक दबाएं</string>
     <string name="tip_genre_filter">शैली के आधार पर परिणामों को फ़िल्टर करने के लिए शैली बटन का उपयोग करें</string>
+    <string name="tip_history">अब आप इतिहास बटन दबाकर अपने चयनों का इतिहास देख सकते हैं</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">अब कभी भी फिल्म चुनने में संघर्ष न करें</string>
     <string name="onboarding_welcome_description">अपनी Letterboxd वॉचलिस्ट और कस्टम सूचियों से यादृच्छिक फिल्म सुझाव प्राप्त करें। फिल्म की रातों के लिए एकदम सही!</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Prova: utente o utente/nome-lista</string>
     <string name="tip_hold_submit">Tieni premuto Invia o i tag per la modalità multiutente</string>
     <string name="tip_genre_filter">Usa il pulsante Genere per filtrare i risultati per genere</string>
+    <string name="tip_history">Ora puoi vedere la tua cronologia delle selezioni premendo il pulsante Cronologia</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">Non avrai più difficoltà a scegliere un film</string>
     <string name="onboarding_welcome_description">Ottieni suggerimenti casuali di film dalle tue liste di visione e liste personalizzate di Letterboxd. Perfetto per le serate cinema!</string>

--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">試す：ユーザー名 または ユーザー名/リスト名</string>
     <string name="tip_hold_submit">マルチユーザーモードにするには、送信またはタグを長押ししてください</string>
     <string name="tip_genre_filter">ジャンルボタンを使って結果をジャンルで絞り込めます</string>
+    <string name="tip_history">履歴ボタンを押すと、これまでの選択履歴を確認できます</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">もう映画選びに迷わない</string>
     <string name="onboarding_welcome_description">Letterboxdのウォッチリストやカスタムリストからランダムな映画を提案します。映画の夜にぴったり！</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Tente: usuário ou usuário/nome-lista</string>
     <string name="tip_hold_submit">Pressione e segure Enviar ou as tags para o modo multiusuário</string>
     <string name="tip_genre_filter">Use o botão Gênero para filtrar os resultados por gênero</string>
+    <string name="tip_history">Agora você pode ver seu histórico de seleções pressionando o botão Histórico</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">Nunca mais tenha dificuldade em escolher um filme</string>
     <string name="onboarding_welcome_description">Receba sugestões aleatórias de filmes das suas listas de observação e listas personalizadas do Letterboxd. Perfeito para noites de cinema!</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Попробуйте: имя_пользователя или имя_пользователя/название_списка</string>
     <string name="tip_hold_submit">Удерживайте «Отправить» или теги для многопользовательского режима</string>
     <string name="tip_genre_filter">Используйте кнопку «Жанр» для фильтрации результатов по жанру</string>
+    <string name="tip_history">Теперь вы можете просмотреть историю своих выборов, нажав кнопку «История»</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">Больше никаких проблем с выбором фильма</string>
     <string name="onboarding_welcome_description">Получайте случайные предложения фильмов из ваших списков просмотра и пользовательских списков Letterboxd. Идеально для киновечеров!</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">尝试：用户名 或 用户名/列表名</string>
     <string name="tip_hold_submit">长按"提交"或标签以启用多用户模式</string>
     <string name="tip_genre_filter">使用"类型"按钮按类型筛选结果</string>
+    <string name="tip_history">现在你可以点击历史记录按钮查看你的挑选记录</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">再也不用为选电影而烦恼</string>
     <string name="onboarding_welcome_description">从您的 Letterboxd 想看列表和自定义列表中获取随机电影建议。非常适合电影之夜！</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="tip_username_format">Try: username or username/list-name</string>
     <string name="tip_hold_submit">Long-press Submit or tags for multi-user mode</string>
     <string name="tip_genre_filter">Use the Genre button to filter results by genre</string>
+    <string name="tip_history">Now you can view your pick history by pressing the History button</string>
     <string name="onboarding_welcome_title">RandomBoxd</string>
     <string name="onboarding_welcome_subtitle">Never struggle to pick a movie again</string>
     <string name="onboarding_welcome_description">Get random movie suggestions from your Letterboxd watchlists and custom lists. Perfect for movie nights!</string>

--- a/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RandomFilmInfoView.kt
+++ b/composeApp/src/commonMain/kotlin/com/nacchofer31/randomboxd/random_film/presentation/components/RandomFilmInfoView.kt
@@ -36,6 +36,7 @@ import randomboxd.composeapp.generated.resources.onboarding_new_badge
 import randomboxd.composeapp.generated.resources.ready_to_spin
 import randomboxd.composeapp.generated.resources.roulette_icon
 import randomboxd.composeapp.generated.resources.tip_genre_filter
+import randomboxd.composeapp.generated.resources.tip_history
 import randomboxd.composeapp.generated.resources.tip_hold_submit
 import randomboxd.composeapp.generated.resources.tip_username_format
 
@@ -123,9 +124,15 @@ fun RandomFilmInfoView() {
                 text = stringResource(Res.string.tip_hold_submit),
                 accentColor = RandomBoxdColors.OrangeAccent,
             )
-            NewFeatureTipCard(
-                newBadge = stringResource(Res.string.onboarding_new_badge),
+            TipCard(
+                icon = "🎭",
                 text = stringResource(Res.string.tip_genre_filter),
+                accentColor = RandomBoxdColors.BlueAccent,
+            )
+            NewFeatureTipCard(
+                icon = "🕘",
+                newBadge = stringResource(Res.string.onboarding_new_badge),
+                text = stringResource(Res.string.tip_history),
             )
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,7 +139,6 @@ ktor = [
 coil = [
     "coil-compose",
     "coil-compose-core",
-    "coil-network-ktor2",
     "coil-network-ktor3",
     "coil-mp"
 ]


### PR DESCRIPTION
## Summary
Enable R8 code shrinking and resource shrinking for the release build type, backed by a new `proguard-rules.pro`. Also removes an unused Coil dependency and adds a new tip card promoting the pick history feature.

## Changes
- **build(android):** turn on `isMinifyEnabled` + `isShrinkResources` for release, with `proguard-android-optimize.txt` and `proguard-rules.pro`
- **build:** add `proguard-rules.pro` with rationale comments
- **chore(deps):** drop `coil-network-ktor2` from the version catalog (only ktor3 is used)
- **feat(ui):** replace the genre-filter tip with a plain `TipCard` and add a "history" `NewFeatureTipCard`, including the `tip_history` string in all 14 locales

## Why no R8 keep rules
Room, kotlinx-serialization and Coil ship their own consumer rules, and Koin 4.x resolves definitions by direct class reference, so R8 retains what's needed without blanket keep rules.