### PR TITLE
release: version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.5.0
+- Added `Pick History` feature.
+- Added `Favorites filter` on history screen.
+- Added `Clear all` on history screen.
+
 ## 1.4.1
 - Prevented film repetition on reroll.
 - Hide `Reroll button` for one results.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ RandomBoxd is a **Compose Multiplatform** project designed to fetch a random mov
 - 🏷️ Stores and displays previously entered UserNames locally via **Room**, shown as tappable tags for quick reuse or deletion.
 - ∩∪ **Intersection & Union** → Combine multiple users' watchlists and pick a random movie either from their **shared movies** (Intersection) or from the **merged pool** (Union).
 - 🎭 **Genre Filters** → Narrow results to one or more genres at once. Works in both single-user and multi-user modes.
+- 🕘 **Pick History** → Every pick is saved locally, so you can review past rolls, filter by favorites, and clear the list anytime.
 
 ## 🧙‍♂️ Watch the Magic
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -136,8 +136,8 @@ android {
 
     defaultConfig {
         applicationId = "com.nacchofer31.randomboxd"
-        versionName = "1.4.1"
-        versionCode = 20
+        versionName = "1.5.0"
+        versionCode = 21
         minSdk =
             libs.versions.android.minSdk
                 .get()


### PR DESCRIPTION
### What
- New **Pick History** screen listing every film pick, saved locally via Room.
- **Favorites filter** to show only favorite picks.
- **Clear all** action to reset the history.
- Onboarding page introducing the history feature.
- Version bump to **1.5.0** (versionCode 21) with updated README and changelog.

### Why
Users need a way to revisit past rolls, mark favorites, and clear their history instead of losing picks between sessions.